### PR TITLE
Google Apps / GSuite authentication support

### DIFF
--- a/config/authentication.google.json
+++ b/config/authentication.google.json
@@ -1,0 +1,6 @@
+{
+  "clientId": "env://AUTH_GOOGLE_CLIENT_ID",
+  "clientSecret": "env://AUTH_GOOGLE_CLIENT_SECRET",
+  "domain": "env://AUTH_GOOGLE_DOMAIN",
+  "redirectUrl": "env://AUTH_GOOGLE_REDIRECT_URL"
+}

--- a/middleware/passport-routes.js
+++ b/middleware/passport-routes.js
@@ -179,17 +179,35 @@ module.exports = function configurePassport(app, passport, initialConfig) {
   // ----------------------------------------------------------------------------
   // passport integration with Azure Active Directory
   // ----------------------------------------------------------------------------
-  var aadMiddleware = initialConfig.authentication.scheme === 'github' ? passport.authorize('azure-active-directory') : passport.authenticate('azure-active-directory');
+  const hasAAD = false;
+  if (hasAAD) {
+    var aadMiddleware = initialConfig.authentication.scheme === 'github' ? passport.authorize('azure-active-directory') : passport.authenticate('azure-active-directory');
 
-  app.get('/auth/azure', aadMiddleware);
+    app.get('/auth/azure', aadMiddleware);
 
-  app.post('/auth/azure/callback', aadMiddleware, authenticationCallback.bind(null, 'aad', 'azure'));
+    app.post('/auth/azure/callback', aadMiddleware, authenticationCallback.bind(null, 'aad', 'azure'));
 
-  app.get('/signin/azure', function (req, res) {
-    utils.storeReferrer(req, res, '/auth/azure', 'request for the /signin/azure page, need to authenticate');
-  });
+    app.get('/signin/azure', function (req, res) {
+      utils.storeReferrer(req, res, '/auth/azure', 'request for the /signin/azure page, need to authenticate');
+    });
 
-  app.get('/signout/azure', processSignout.bind(null, 'aad', 'azure'));
+    app.get('/signout/azure', processSignout.bind(null, 'aad', 'azure'));
+  }
 
+  const hasGoogle = true;
+  if (hasGoogle) {
+    const googleMiddleware = passport.authenticate('google');
+
+    app.get('/auth/google', googleMiddleware);
+
+    app.get('/auth/google/callback', googleMiddleware, authenticationCallback.bind(null, 'google', 'google'));
+
+    app.get('/signin/google', function (req, res) {
+      utils.storeReferrer(req, res, '/auth/google', 'request for the /signin/google page, need to authenticate');
+    });
+
+    app.get('/signout/google', processSignout.bind(null, 'aad', 'azure'));
+
+  }
 };
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "painless-config-resolver": "1.0.0",
     "passport": "^0.3.2",
     "passport-azure-ad": "^3.0.5",
+    "passport-google-oauth20": "^1.0.0",
     "passport-strategy": "1.x.x",
     "pug": "=2.0.0-beta4",
     "q": "^1.5.0",

--- a/routes/index-authenticated.js
+++ b/routes/index-authenticated.js
@@ -20,8 +20,10 @@ const utils = require('../utils');
 
 router.use(function (req, res, next) {
   var config = req.app.settings.runtimeConfig;
+  const authType = 'google'; // 'azure'
+  const redirectType = 'google'; // 'azure'
   if (req.isAuthenticated()) {
-    var expectedAuthenticationProperty = config.authentication.scheme === 'github' ? 'github' : 'azure';
+    var expectedAuthenticationProperty = config.authentication.scheme === 'github' ? 'github' : authType;
     if (req.user && !req.user[expectedAuthenticationProperty]) {
       console.warn(`A user session was authenticated but did not have present the property "${expectedAuthenticationProperty}" expected for this type of authentication. Signing them out.`);
       return res.redirect('/signout');
@@ -32,7 +34,7 @@ router.use(function (req, res, next) {
     }
     return next();
   }
-  utils.storeOriginalUrlAsReferrer(req, res, config.authentication.scheme === 'github' ? '/auth/github' : '/auth/azure', 'user is not authenticated and needs to authenticate');
+  utils.storeOriginalUrlAsReferrer(req, res, config.authentication.scheme === 'github' ? '/auth/github' : '/auth/' + redirectType, 'user is not authenticated and needs to authenticate');
 });
 
 router.use((req, res, next) => {


### PR DESCRIPTION
Supports using Google Authentication with a specific GSuite domain
as opposed to using Azure Active Directory.

Expected new configuration values:

- `AUTH_GOOGLE_CLIENT_ID`
- `AUTH_GOOGLE_CLIENT_SECRET`
- `AUTH_GOOGLE_DOMAIN` (the GSuite domain name to restrict linking, app users to)
- `AUTH_GOOGLE_REDIRECT_URL`

_This is a work in progress, not yet ready to be merged_
