### PR TITLE
Large permission grant protections/blocks

### DIFF
--- a/business/operations.js
+++ b/business/operations.js
@@ -33,6 +33,7 @@ const defaults = {
   repoBranchesStaleSeconds: 60 * 5 /* 5m */,
   accountDetailStaleSeconds: 60 * 60 * 24 /* 24h */,
   orgRepoWebhooksStaleSeconds: 60 * 60 * 8 /* 8h */,
+  teamRepositoryPermissionStaleSeconds: 0 /* 0m */,
 };
 
 class Operations {

--- a/business/organization.js
+++ b/business/organization.js
@@ -92,6 +92,10 @@ class Organization {
     return _private(this).settings.externalMembersPermitted || false;
   }
 
+  get preventLargeTeamPermissions() {
+    return _private(this).settings.preventLargeTeamPermissions || false;
+  }
+
   get description() {
     return _private(this).settings.description;
   }

--- a/business/team.js
+++ b/business/team.js
@@ -289,6 +289,40 @@ class Team {
       common.createInstancesCallback(this, this.memberFromEntity, callback));
   }
 
+  checkRepositoryPermission(repositoryName, options, callback) {
+    if (!callback && typeof (options) === 'function') {
+      callback = options;
+      options = null;
+    }
+    options = options || {};
+    let privates = _private(this);
+    let operations = privates.operations;
+    let token = privates.getToken();
+    let github = operations.github;
+    const organizationName = options.organizationName || this.organization.name;
+    const parameters = {
+      id: this.id,
+      owner: organizationName,
+      repo: repositoryName,
+    };
+    const cacheOptions = {
+      maxAgeSeconds: options.maxAgeSeconds || operations.defaults.teamRepositoryPermissionStaleSeconds,
+    };
+    if (options.backgroundRefresh !== undefined) {
+      cacheOptions.backgroundRefresh = options.backgroundRefresh;
+    }
+    parameters.headers = {
+      // Alternative response for additional information, including the permission level
+      'Accept': 'application/vnd.github.v3.repository+json',
+    };
+    return github.call(token, 'orgs.checkTeamRepo', parameters, cacheOptions, (error, details) => {
+      if (error) {
+        return callback(error);
+      }
+      return callback(null, details && details.permissions ? details.permissions : null);
+    });
+  }
+
   getRepositories(options, callback) {
     if (!callback && typeof (options) === 'function') {
       callback = options;

--- a/jobs/firehose/task.js
+++ b/jobs/firehose/task.js
@@ -124,8 +124,10 @@ module.exports = function runFirehoseTask(started, startedString, config) {
       isPeekLock: true,
     }, (peekError, lockedMessage) => {
       if (!lockedMessage) {
+        console.log(`[empty queue] ${emptyQueueDelaySeconds}s until retry`);
         return setTimeout(callback, emptyQueueDelaySeconds * 1000);
       }
+      console.log(`[message ${lockedMessage.brokerProperties.MessageId}] dequeued`);
       const insights = app.settings.appInsightsClient;
 
       let object = null;
@@ -148,6 +150,7 @@ module.exports = function runFirehoseTask(started, startedString, config) {
         insights.trackMetric('JobFirehoseQueueDelay', totalMs);
       }
       const acknowledgeEvent = function () {
+        console.log(`[message ${lockedMessage.brokerProperties.MessageId}] acknowledged (deleted)`);
         serviceBusService.deleteMessage(lockedMessage, (deleteError) => {
           if (deleteError) {
             console.dir(deleteError);

--- a/lib/github/core.js
+++ b/lib/github/core.js
@@ -293,7 +293,9 @@ function normalizedOptionsString(options) {
   sortedkeys.forEach((key) => {
     let value = options[key];
     const typeOf = typeof (value);
-    if (typeOf !== 'string' && typeOf !== 'number' && typeOf !== 'boolean') {
+    if (typeOf === 'object') {
+      value = normalizedOptionsString(value);
+    } else if (typeOf !== 'string' && typeOf !== 'number' && typeOf !== 'boolean') {
       throw new Error(`Normalized option ${key} is not a string`);
     }
     if (typeOf === 'boolean') {

--- a/lib/github/restApi.js
+++ b/lib/github/restApi.js
@@ -197,6 +197,10 @@ function callGithubApi(apiContext) {
   const headers = {
     Authorization: `token ${token}`,
   };
+  if (apiContext.options.headers) {
+    apiContext.headers = apiContext.options.headers;
+    Object.assign(headers, apiContext.headers);
+  }
   if (apiContext.etag) {
     headers['If-None-Match'] = apiContext.etag;
   }

--- a/middleware/initialize.js
+++ b/middleware/initialize.js
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-/*eslint no-console: ["error", { allow: ["log", "error", "dir"] }] */
+/*eslint no-console: ["error", { allow: ["log", "warn", "error", "dir"] }] */
 
 'use strict';
 

--- a/webhooks/organizationProcessor.js
+++ b/webhooks/organizationProcessor.js
@@ -66,6 +66,9 @@ module.exports = function (options, callback) {
     });
     if (work.length > 0) {
       ++interestingEvents;
+      console.log(`[* interesting event found: ${event.properties.event} (${work.length} interested tasks)]`);
+    } else {
+      console.log(`[skipping event: ${event.properties.event}]`);
     }
     async.eachSeries(work, (processor, next) => {
       try {

--- a/webhooks/tasks/automaticTeams.js
+++ b/webhooks/tasks/automaticTeams.js
@@ -142,7 +142,7 @@ module.exports = {
 
 function teamTooLargeForPurpose(teamId, isAdmin, isPush, organization, teamSize, preventLargeTeamPermissions) {
   const broadAccessTeams = organization.broadAccessTeams;
-  let isBroadAccessTeam = broadAccessTeams && broadAccessTeams.indexOf(teamId) >= 0;
+  let isBroadAccessTeam = broadAccessTeams && broadAccessTeams.includes(teamId);
   if (isBroadAccessTeam && (isAdmin || isPush)) {
     return 'The team is a very broad access team and does not allow push or admin access';
   }

--- a/webhooks/tasks/automaticTeams.js
+++ b/webhooks/tasks/automaticTeams.js
@@ -37,7 +37,7 @@ module.exports = {
     const eventAction = data.body.action;
 
     // Someone added a team to the repo
-    if (eventType === 'team' && (eventAction === 'add_repository' || eventAction === 'added_to_repository')) {
+    if (eventType === 'team' && ['add_repository', 'added_to_repository'].includes(eventAction)) {
       return true;
     }
 

--- a/webhooks/tasks/automaticTeams.js
+++ b/webhooks/tasks/automaticTeams.js
@@ -109,9 +109,6 @@ module.exports = {
           if (newPermissions[necessaryPermission] !== true) {
             recoveryTasks.push(createSetTeamPermissionTask(operations, organization, repositoryBody, teamId, necessaryPermission, `the permission was downgraded by the username ${whoChangedIt}`));
           }
-        } else if (eventAction === 'removed_from_repository') {
-          // Someone removed the entire team
-          recoveryTasks.push(createSetTeamPermissionTask(operations, organization, repositoryBody, teamId, necessaryPermission, `the team and its permission were removed by the username ${whoChangedIt}`));
         }
         return finalizeEventRemediation();
       }


### PR DESCRIPTION
This adds a feature to block large permission grants (write and/or admin) to teams that are "very large".

A common scenario we see:
- A user unfamiliar with the specifics of GitHub permissions creates a new repository; they receive administrative rights over their new repo
- The user wants to collaborate with others in the organization
- User goes to GitHub, collaborators tab for their repo, and adds a team such as "Everyone at Microsoft" to the repository
- User changes the permission level from "read" to "admin" [or write], not understanding the implications
- Over 7,000+ users are given administrative permission over the repo
- Over 7,000+ users get annoyed if they have 'automatically watch new repositories' configured in their GitHub notification settings
- Over 7,000+ users get annoyed that they are receiving GitHub "spam" or notification digests internally about their new permissions & repo that they have no context about

Dependencies:
- Application subscribed to either a Service Bus topic with all organization webhook events from GitHub, or the app directly attached to organizations as a webhook receiver itself

Configuration:
- Must be enabled at the org level via an organization configuration value in JSON/environment `preventLargeTeamPermissions`

This extends the existing new-repository organization webhook processing logic where "all read/write/admin" team functionality is already implemented at repo create time.

The feature is opt-in at the organization level with this first implementation by setting a new configuration variable called `preventLargeTeamPermissions` to true.

## Implementation behavior

When there is a new team/repository permission entry, or a change:

- *IF* the permission is now admin _or_ write _and_ it is a "broad access team" as defined by organization configuration (typically the 'Everyone' team for an org used when joining new members via invites), immediately downgrade to READ permission
- *ELSE IF* the permission is now admin _and_ the team has more than 100 people in it (or the org-configured value), reject and revert back to read for the team's access

Need to figure out if it is OK for any of the main operational service accounts to perform these changes or if they should be universal.

Follow-up for a future commit: sending a mail message to the initiator of the upgraded permission, if a mail provider is available.

To override the 100 administrator per team member count level, set the property instead to be an object that contains a value for `maximumAdministrators` within that object

## Other changes

- Adds permission check API to teams; given a repo name, check and return permissions
- Supporting the REST API provider caching system to support header values that impact the outcome. GitHub's "check permissions for a team" requires a header to alter the behavior from an HTTP status-only result to a body with the permission data. This header request gets embedded in the key used for the cache lookup
- Improved service bus messaging to the console for WebJob-related firehose operations, to improve debuggability

## GitHub API change

On 6/14/17 Ivan at GitHub helped roll out a fix/ask of ours related to this API. As a result the permissions no longer need to be proactively retrieved.