### PR TITLE
Downgrading broad admin access in repo create API

### DIFF
--- a/routes/api/createRepo.js
+++ b/routes/api/createRepo.js
@@ -223,13 +223,18 @@ function downgradeBroadAccessTeams(organization, teams) {
   if (teams.admin && Array.isArray(teams.admin)) {
     _.remove(teams.admin, teamId => {
       if (broadAccessTeams.has(teamId)) {
+        if (!teams.pull) {
+          teams.pull = [];
+        }
         teams.pull.push(teamId);
         return true;
       }
       return false;
     });
   }
-  teams.pull = _.uniq(teams.pull); // deduplicate
+  if (teams.pull && Array.isArray(teams.pull)) {
+    teams.pull = _.uniq(teams.pull); // deduplicate
+  }
 }
 
 function rollbackRepoError(req, res, next, error, statusCode, errorToLog) {


### PR DESCRIPTION
Similar to #30, working to protect large swaths of admin permission grants. This change actively downgrades 'admin' permissions to the broad/everyone teams to 'read' only.

A nice-to-have future improvement on this might be to add configuration to opt in or out of this feature if you have a scenario where you want such a large grant.