### PR TITLE
Fixing tests

### DIFF
--- a/test/configuration.js
+++ b/test/configuration.js
@@ -33,7 +33,7 @@ describe('configuration', () => {
         e: 5,
       };
       keyVaultClient.getObjectSecrets(config, (error) => {
-        assert.isNull(error, 'no exception');
+        assert.isUndefined(error, 'no exception');
         assert.equal(config.a, 'animal', 'string works');
         assert.equal(config.b, 'bat', 'string works');
         assert.equal(config.c, 'cherry', 'string works');
@@ -110,7 +110,7 @@ describe('configuration', () => {
         a: secretId,
       };
       keyVaultClient.getObjectSecrets(config, (error) => {
-        assert.isNull(error, 'no exception');
+        assert.isUndefined(error, 'no exception');
         assert.equal(config.a, secretId, 'KeyVault URL is passed through');
       });
     });


### PR DESCRIPTION
2 tests are failing:

```
18 passing (22ms)
2 failing

  1) configuration keyVaultHelper non-URL values passthrough:
     AssertionError: no exception: expected undefined to equal null
      at Function.assert.isNull (node_modules/chai/lib/chai/interface/assert.js:407:32)
      at keyVaultClient.getObjectSecrets (test/configuration.js:36:16)
      at async.each.error (node_modules/keyvault-configuration-resolver/lib/index.js:129:14)
      at node_modules/async/dist/async.js:421:16
      at eachOfArrayLike (node_modules/async/dist/async.js:991:9)
      at eachOf (node_modules/async/dist/async.js:1051:5)
      at Object.eachLimit (node_modules/async/dist/async.js:3122:5)
      at Object.resolveSecrets [as getObjectSecrets] (node_modules/keyvault-configuration-resolver/lib/index.js:111:11)
      at Context.it (test/configuration.js:35:22)

  2) configuration keyVaultHelper URL values passthrough:
     AssertionError: no exception: expected undefined to equal null
      at Function.assert.isNull (node_modules/chai/lib/chai/interface/assert.js:407:32)
      at keyVaultClient.getObjectSecrets (test/configuration.js:113:16)
      at async.each.error (node_modules/keyvault-configuration-resolver/lib/index.js:129:14)
      at node_modules/async/dist/async.js:421:16
      at eachOfArrayLike (node_modules/async/dist/async.js:991:9)
      at eachOf (node_modules/async/dist/async.js:1051:5)
      at Object.eachLimit (node_modules/async/dist/async.js:3122:5)
      at Object.resolveSecrets [as getObjectSecrets] (node_modules/keyvault-configuration-resolver/lib/index.js:111:11)
      at Context.it (test/configuration.js:112:22)
```

It looks like we are asserting that the callback was `null` when I think it should be `undefined`.

This returns `undefined` https://github.com/Microsoft/keyvault-configuration-resolver-node/blob/master/lib/index.js#L89-L129
