### PR TITLE
Lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "bower": "^1.7.9",
     "chai": "^3.5.0",
-    "eslint": "^3.17.1",
+    "eslint": "^4.0.0",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   ],
   "scripts": {
     "start": "node ./bin/www",
-    "test": "mocha && eslint .",
-    "build": "bower install && grunt"
+    "test": "mocha && npm run lint",
+    "build": "bower install && grunt",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "engines": {
     "node": "~6.9.0"


### PR DESCRIPTION
* Added `npm` script to lint
* Added `npm` script to fix lint
* Updated `npm test` to call the newly created `npm` script
* Bumped `eslint` to `4.0.0` since previous version was not catching lint.  Once merged there will be lint unless https://github.com/Microsoft/opensource-portal/pull/54 is merged first.

Sorry about all the PRs!