### PR TITLE
Layout, config: adding continuous deployment config

### DIFF
--- a/config/continuousDeployment.js
+++ b/config/continuousDeployment.js
@@ -1,0 +1,15 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+'use strict';
+
+module.exports = graphApi => {
+  // Useful information to help understand which CI/CD pipeline the app came from
+  const packageJson = require('../package.json');
+  const continuousDeployment = packageJson.continuousDeployment || {};
+  continuousDeployment.version = packageJson.version;
+  continuousDeployment.name = packageJson.name;
+  return continuousDeployment;
+};

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -21,3 +21,10 @@ html(lang="en")
     include footer
     include insights
     include ga
+    if config && config.continuousDeployment
+      != '\n<!--'
+      != (config.continuousDeployment.commitId ? '\nCommit ' + config.continuousDeployment.commitId : '')
+      != (config.continuousDeployment.build ? '\nBuild ' + config.continuousDeployment.build : '')
+      != (config.continuousDeployment.release ? '\nRelease ' + config.continuousDeployment.release : '')
+      != (config.continuousDeployment.name && config.continuousDeployment.version ? '\nPackage ' + config.continuousDeployment.name + ' ' + config.continuousDeployment.version : '')
+      != '\n-->'


### PR DESCRIPTION
Adds the ability to show basic build info such as build, release, commit ID, _if_ that information is provided inside the `package.json` for the app. Otherwise, no-op.