### PR TITLE
New repo client API: allow public repositories

### DIFF
--- a/business/organization.js
+++ b/business/organization.js
@@ -497,10 +497,9 @@ function getSupportedRepositoryTypesByPriority(self) {
   // plan.
   const settings = _private(self).settings;
   const type = settings.type || 'public';
-  let types = [];
+  let types = ['public'];
   switch (type) {
   case 'public':
-    types.push('public');
     break;
   case 'publicprivate':
     types.push('private');

--- a/business/organization.js
+++ b/business/organization.js
@@ -117,6 +117,10 @@ class Organization {
     return getSpecialTeam(this, 'teamAllMembers', 'everyone membership');
   }
 
+  get privateRepositoriesSupported() {
+    return getSupportedRepositoryTypesByPriority(this).includes('private');
+  }
+
   get sudoersTeam() {
     const teams = getSpecialTeam(this, 'teamSudoers', 'organization sudoers');
     if (teams.length > 1) {
@@ -243,6 +247,7 @@ class Organization {
       },
       supportsCla: settings.cla && true,
       templates: getRepositoryCreateTemplates(this, operations),
+      visibilities: getSupportedRepositoryTypesByPriority(this),
     };
     return metadata;
   }
@@ -482,6 +487,34 @@ class Organization {
   repositoryFromEntity(entity) {
     return this.repository(entity.name, entity);
   }
+}
+
+function getSupportedRepositoryTypesByPriority(self) {
+  // Returns the types of repositories supported by the configuration for the organization.
+  // The returned array position 0 represents the recommended default choice for new repos.
+  // Note that while the configuration may say 'private', the organization may not have
+  // a billing relationship, so repo create APIs would fail asking you to upgrade to a paid
+  // plan.
+  const settings = _private(self).settings;
+  const type = settings.type || 'public';
+  let types = [];
+  switch (type) {
+  case 'public':
+    types.push('public');
+    break;
+  case 'publicprivate':
+    types.push('private');
+    break;
+  case 'private':
+    types.splice(0, 1, 'private');
+    break;
+  case 'privatepublic':
+    types.splice(0, 0, 'private');
+    break;
+  default:
+    throw new Error(`Unsupported configuration for repository types in the organization: ${type}`);
+  }
+  return types;
 }
 
 function getOwnerToken() {

--- a/routes/api/client/newOrgRepo.js
+++ b/routes/api/client/newOrgRepo.js
@@ -138,6 +138,7 @@ function discoverUserIdentities(req, res, next) {
 
 router.post('/repo/:repo', discoverUserIdentities, (req, res, next) => {
   const body = req.body;
+  const organization = req.organization;
   if (!body) {
     return next(jsonError('No body', 400));
   }
@@ -149,9 +150,12 @@ router.post('/repo/:repo', discoverUserIdentities, (req, res, next) => {
     body['ms.onBehalfOf'] = oss.usernames.github;
   }
 
-  // Today we always create a private repo if we can
-  // TODO: POST 1ES-DAY: Figure out the proper org config value here
-  body.private = true;
+  // Allow public or private repository visibility, if the configuration
+  // permits, but default to private for now until a user interface is
+  // built.
+  const createMetadata = organization.getRepositoryCreateMetadata();
+  const supportedVisibilities = createMetadata.visibilities || ['public'];
+  body.private = supportedVisibilities.includes('private');
 
   // these fields do not need translation: name, description
 


### PR DESCRIPTION
The original implementation for 1ES day was specifically targeted at
private only. This aligns with the configuration values in the orgs.