### PR TITLE
NPM Script: Remove lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "start": "node ./bin/www",
     "test": "mocha && npm run lint",
     "build": "bower install && grunt",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint ."
   },
   "engines": {
     "node": "~6.9.0"


### PR DESCRIPTION
Hi.  I realized that creating a lint script just to pass in an argument to an npm sciript probably isn't the right thing to do considering npm scripts support passing in arguments out of the box.

https://docs.npmjs.com/cli/run-script

In this case it would be:
`npm run lint -- --fix`