### PR TITLE
opt-in feature: repo lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,3 +319,21 @@ For performance reasons, a partitioned/purpose-intended app model is
 being designed that will fallback to the one configured app installation,
 if any. If there is no modern GitHub app, the GitHub PAT for an org will
 be used.
+
+# Feature flags
+
+Under development, configuration values in `config/features.json` map
+explicit opt-in environment variables to features and functions for
+the monolithic site.
+
+This was, organizations can choose which specific features they may
+want to have exposed by the app.
+
+Most features can be opted in to by simply setting the environment
+variable value to `1`.
+
+- allowUnauthorizedNewRepositoryLockdownSystem
+
+  - Variable: `FEATURE_FLAG_ALLOW_UNAUTHORIZED_NEW_REPOSITORY_LOCKDOWN_SYSTEM`
+  - Purpose: Allows the "unauthorized new repository lockdown system" to be _available_ as an organization feature flag. It does not turn this system on by default in any case.
+  - Requirements: the event firehose must be used (there is no equivalent job, to make sure to not accidentially destroy permissions across existing repos)

--- a/business/organization.ts
+++ b/business/organization.ts
@@ -856,7 +856,7 @@ export class Organization {
   // Specialized features, opt-in only
 
   isNewRepositoryLockdownSystemEnabled() {
-    return this._operations.allowUnauthorizedNewRepositoryLockdownSystemFeature() && true; // && this._settings.hasFeature('new-repository-lockdown-system');
+    return this._operations.allowUnauthorizedNewRepositoryLockdownSystemFeature() && this._settings.hasFeature('new-repository-lockdown-system');
   }
 
   // Helper functions

--- a/business/organization.ts
+++ b/business/organization.ts
@@ -853,6 +853,14 @@ export class Organization {
     return templates;
   }
 
+  // Specialized features, opt-in only
+
+  isNewRepositoryLockdownSystemEnabled() {
+    return this._operations.allowUnauthorizedNewRepositoryLockdownSystemFeature() && true; // && this._settings.hasFeature('new-repository-lockdown-system');
+  }
+
+  // Helper functions
+
   memberFromEntity(entity): OrganizationMember {
     return this.member(entity.id, entity);
   }

--- a/business/repository.ts
+++ b/business/repository.ts
@@ -508,6 +508,15 @@ export class Repository {
     return this._operations.github.post(this.authorize(AppPurpose.Operations), 'teams.addOrUpdateRepo', options);
   }
 
+  removeTeamPermission(teamId: number): Promise<any> {
+    const options = {
+      team_id: teamId,
+      owner: this.organization.name,
+      repo: this.name,
+    };
+    return this._operations.github.post(this.authorize(AppPurpose.Operations), 'teams.removeRepo', options);
+  }
+
   async getWebhooks(options?: ICacheOptions): Promise<any> {
     options = options || {};
     const operations = this._operations

--- a/config/features.json
+++ b/config/features.json
@@ -1,0 +1,3 @@
+{
+  "allowUnauthorizedNewRepositoryLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_NEW_REPOSITORY_LOCKDOWN_SYSTEM?trueIf=1"
+}

--- a/features/newRepositoryLockdown.ts
+++ b/features/newRepositoryLockdown.ts
@@ -1,0 +1,221 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { Operations } from '../business/operations';
+import { Organization } from '../business/organization';
+import { Repository } from '../business/repository';
+import { Team } from '../business/team';
+import { ICorporateLink } from '../business/corporateLink';
+import { IMail } from '../lib/mailProvider';
+import { IRepositoryMetadataProvider } from '../entities/repositoryMetadata/repositoryMetadataProvider';
+import { RepositoryMetadataEntity } from '../entities/repositoryMetadata/repositoryMetadata';
+
+const botBracket = '[bot]';
+
+interface IMailToLockdownRepo {
+  username: string;
+  log: string[];
+  organization: Organization;
+  repository: Repository;
+  linkToClassifyRepository: string;
+  mailAddress?: string;
+  link?: ICorporateLink;
+}
+
+export interface INewRepositoryLockdownSystemOptions {
+  operations: Operations;
+  organization: Organization;
+  repository: Repository;
+  repositoryMetadataProvider: IRepositoryMetadataProvider;
+}
+
+export default class NewRepositoryLockdownSystem {
+  organization: Organization;
+  operations: Operations;
+  repository: Repository;
+  repositoryMetadataProvider: IRepositoryMetadataProvider;
+
+  constructor(options: INewRepositoryLockdownSystemOptions) {
+    this.organization = options.organization;
+    this.operations = options.operations;
+    this.repository = options.repository;
+    this.repositoryMetadataProvider = options.repositoryMetadataProvider;
+  }
+
+  private populateRepositoryMetadata(entity: RepositoryMetadataEntity, username: string, userId: number, link: ICorporateLink) {
+    entity.createdByThirdPartyUsername = username;
+    entity.createdByThirdPartyId = userId.toString();
+    if (link) {
+      entity.createdByCorporateDisplayName = link.corporateDisplayName;
+      entity.createdByCorporateId = link.corporateId;
+      entity.createdByCorporateUsername = link.corporateUsername;
+    }
+    return entity;
+  }
+
+  async lockdownIfNecessary(username: string, thirdPartyId: number): Promise<boolean> {
+    const lockdownLog: string[] = [];
+    // reconfirm that the new repository system is enabled for this organization
+    if (!this.organization.isNewRepositoryLockdownSystemEnabled()) {
+      return false;
+    }
+    lockdownLog.push(`Confirmed that the ${this.organization.name} organization has opted in to the new repository lockdown system`);
+    const lowercaseUsername = username.toLowerCase();
+    // any repository created by a bot *is ok* and will not be locked down. If this is an issue, having an approved list of permitted bots to create repos would be one way to approach this loophole. Non-bot users cannot have brackets in their names.
+    if (lowercaseUsername.includes(botBracket)) {
+      return false;
+    }
+    lockdownLog.push('Confirmed that the repository was not created by a bot');
+    // a repository created by one of the operations accounts in the allowed list is OK and will not be locked down
+    const systemAccounts = new Set(this.operations.systemAccountsByUsername.map(username => username.toLowerCase()));
+    if (systemAccounts.has(lowercaseUsername)) {
+      return false;
+    }
+    lockdownLog.push(`Confirmed that the repository was not created by any of the system accounts: ${Array.from(systemAccounts.values()).join(', ')}`);
+    await this.lockdownRepository(lockdownLog, systemAccounts);
+    let link: ICorporateLink = null;
+    try {
+      link = await this.operations.getLinkByThirdPartyId(thirdPartyId.toString());
+    } catch (noLinkError) {
+      lockdownLog.push(`No corporate link available for the GitHub username ${username} that created the repository`);
+    }
+    try {
+      // Repository metadata is used to lock down the security of the repository system. Only
+      // a complete system administrator or the initial creator of a repository is able to
+      // complete the initial repository setup process.
+      let repositoryMetadata: RepositoryMetadataEntity = null;
+      try {
+        repositoryMetadata = await this.repositoryMetadataProvider.getRepositoryMetadata(this.repository.id.toString());
+      } catch (doesNotExist) {
+        // ignore: 404 is standard here
+      }
+      if (repositoryMetadata) {
+        lockdownLog.push(`Repository metadata already exists for repository ID ${this.repository.id}`);
+        await this.repositoryMetadataProvider.updateRepositoryMetadata(this.populateRepositoryMetadata(repositoryMetadata, username, thirdPartyId, link));
+        lockdownLog.push(`Updated the repository metadata with username and link information`);
+      } else {
+        repositoryMetadata = this.populateRepositoryMetadata(new RepositoryMetadataEntity(), username, thirdPartyId, link);
+        repositoryMetadata.created = new Date();
+        repositoryMetadata.repositoryId = this.repository.id.toString();
+        repositoryMetadata.repositoryName = this.repository.name;
+        repositoryMetadata.organizationName = this.organization.name;
+        repositoryMetadata.organizationId = this.organization.id.toString();
+        await this.repositoryMetadataProvider.createRepositoryMetadata(repositoryMetadata);
+        lockdownLog.push(`Created the initial repository metadata indicating the repo was created by ${username}`);
+      }
+    } catch (metadataSystemError) {
+      console.dir(metadataSystemError);
+      lockdownLog.push(`While writing repository metadata an error: ${metadataSystemError.message}`);
+    }
+    let mailSentToCreator = false;
+    const lockdownMailContent: IMailToLockdownRepo = {
+      username,
+      log: lockdownLog,
+      organization: this.organization,
+      repository: this.repository,
+      linkToClassifyRepository: 'https://google.com', // TODO: link similar to https://repos.opensource.microsoft.com/microsoft/wizard?existingreponame=opensource-portal
+      mailAddress: null,
+      link,
+    };
+    if (link) {
+      try {
+        const mailAddress = await this.operations.getMailAddressFromCorporateUsername(link.corporateUsername);
+        if (mailAddress) {
+          const mailToCreator: IMail = {
+            to: mailAddress,
+            subject: `Please complete the setup of your new GitHub repository ${this.repository.name} (${username})`,
+            content: await this.operations.emailRender('newrepolockdown', {
+              reason: (`You just created a repository on GitHub and have additional actions required to gain access to continue to use it after classification.
+                        This mail was sent to: ${mailAddress}`),
+              headline: `Setup your new repository`,
+              notification: 'information',
+              app: `${this.operations.config.brand.companyName} GitHub`,
+              isMailToCreator: true,
+              lockdownMailContent,
+            }),
+          };
+          await this.operations.sendMail(mailToCreator);
+          lockdownLog.push(`sent an e-mail to the repository creator ${mailAddress} (corporate username: ${link.corporateUsername})`);
+          mailSentToCreator = true;
+        } else {
+          lockdownLog.push(`no e-mail address available for the corporate username ${link.corporateUsername}`);
+        }
+      } catch (noLinkOrEmail) {
+        console.dir(noLinkOrEmail);
+      }
+    }
+    const operationsMail = this.operations.getOperationsMailAddress();
+    if (operationsMail) {
+      try {
+        const mailToOperations: IMail = {
+          to: operationsMail,
+          subject: `A new repository ${this.organization.name}/${this.repository.name} was created directly on GitHub by ${username}`,
+          content: await this.operations.emailRender('newrepolockdown', {
+            reason: (`A user just created this new repository directly on GitHub. As the operations contact for this system, you are receiving this e-mail.
+                      This mail was sent to: ${operationsMail}`),
+            headline: `New repo ${this.organization.name}/${this.repository.name} created by ${username}`,
+            notification: 'information',
+            app: `${this.operations.config.brand.companyName} GitHub`,
+            isMailToOperations: true,
+            lockdownMailContent,
+            mailSentToCreator,
+          }),
+        };
+        await this.operations.sendMail(mailToOperations);
+        lockdownLog.push(`sent an e-mail to the operations contact ${operationsMail}`);
+      } catch (mailIssue) {
+        console.dir(mailIssue);
+      }
+    }
+    console.dir(lockdownLog);
+    return true;
+  }
+
+  async lockdownRepository(log: string[], systemAccounts: Set<string>): Promise<void> {
+    try {
+      const specialPermittedTeams = new Set([
+        ...this.organization.specialRepositoryPermissionTeams.admin,
+        ...this.organization.specialRepositoryPermissionTeams.write,
+        ...this.organization.specialRepositoryPermissionTeams.read]);
+      const teamPermissions = await this.repository.getTeamPermissions();
+      for (const tp of teamPermissions) {
+        if (specialPermittedTeams.has(tp.team.id)) {
+          log.push(`Special permitted team id=${tp.team.id} name=${tp.team.name} will continue to have repository access`);
+        } else {
+          await this.tryDropTeam(this.repository, tp.team, log);
+        }
+      }
+      const collaborators = await this.repository.getCollaborators();
+      for (const collaborator of collaborators) {
+        if (systemAccounts.has(collaborator.login.toLowerCase())) {
+          log.push(`System account ${collaborator.login} will continue to have repository access`);
+        } else {
+          await this.tryDropCollaborator(this.repository, collaborator.login, log);
+        }
+      }
+      log.push('Lockdown of permissions complete');
+    } catch (lockdownError) {
+      log.push(`Error while locking down the repository: ${lockdownError.message}`);
+    }
+  }
+
+  async tryDropTeam(repository: Repository, team: Team, log: string[]): Promise<void> {
+    try {
+      const result = await repository.removeTeamPermission(team.id);
+      log.push(`Lockdown removed team id=${team.id} name=${team.name} from the repository ${repository.name} in organization ${repository.organization.name}`);
+    } catch (lockdownError) {
+      log.push(`Error while removing team id=${team.id} name=${team.name} permission from the repository ${repository.name} in organization ${repository.organization.name}: ${lockdownError.message}`);
+    }
+  }
+
+  async tryDropCollaborator(repository: Repository, login: string, log: string[]): Promise<void> {
+    try {
+      const result = await repository.removeCollaborator(login);
+      log.push(`Lockdown removed collaborator login=${login} from the repository ${repository.name} in organization ${repository.organization.name}`);
+    } catch (lockdownError) {
+      log.push(`Error while removing collaborator login=${login} from the repository ${repository.name} in organization ${repository.organization.name}: ${lockdownError.message}`);
+    }
+  }
+}

--- a/routes/org/team/maintainers.ts
+++ b/routes/org/team/maintainers.ts
@@ -6,35 +6,37 @@
 'use strict';
 
 import express = require('express');
-import { ReposAppRequest } from '../../../transitional';
+import asyncHandler from 'express-async-handler';
 const router = express.Router();
+
+import { ReposAppRequest } from '../../../transitional';
+import { Team } from '../../../business/team';
+import { TeamMember } from '../../../business/teamMember';
 const teamAdminRequired = require('./teamAdminRequired');
 
 interface ILocalRequest extends ReposAppRequest {
-  team2?: any;
+  team2?: Team;
   verifiedCurrentMaintainers?: any;
   teamUrl?: any;
   team2AddType?: any;
 }
 
-function refreshMaintainers(team2, callback) {
-  const options = {
+router.use(asyncHandler(async (req: ILocalRequest, res, next) => {
+  // Get the latest maintainers, forced, with every request
+  const team2 = req.team2 as Team;
+  const maintainers = await refreshMaintainers(team2);
+  if (maintainers) {
+    req.verifiedCurrentMaintainers = maintainers;
+  }
+  return next();
+}));
+
+async function refreshMaintainers(team2: Team): Promise<TeamMember[]> {
+  return team2.getMaintainers({
     maxAgeSeconds: -1,
     backgroundRefresh: false,
-  };
-  team2.getMaintainers(options, callback);
-}
-
-router.use((req: ILocalRequest, res, next) => {
-  // Get the latest maintainers with every request
-  const team2 = req.team2;
-  refreshMaintainers(team2, (error, maintainers) => {
-    if (maintainers) {
-      req.verifiedCurrentMaintainers = maintainers;
-    }
-    return next(error);
   });
-});
+}
 
 router.get('/refresh', (req: ILocalRequest, res) => {
   // Since the views are cached, this can help resolve support situations before they start
@@ -42,8 +44,8 @@ router.get('/refresh', (req: ILocalRequest, res) => {
 });
 
 
-router.post('/:id/downgrade', teamAdminRequired, (req: ILocalRequest, res, next) => {
-  const team2 = req.team2;
+router.post('/:id/downgrade', teamAdminRequired, asyncHandler(async (req: ILocalRequest, res, next) => {
+  const team2 = req.team2 as Team;
   const id = req.params.id;
   const verifiedCurrentMaintainers = req.verifiedCurrentMaintainers;
 
@@ -58,41 +60,25 @@ router.post('/:id/downgrade', teamAdminRequired, (req: ILocalRequest, res, next)
     return next(new Error(`The GitHub user with ID ${id} is not currently a maintainer of the team, so cannot be downgraded.`));
   }
   const username = maintainer.login;
-  team2.addMembership(username, changeMembershipError => {
-    if (changeMembershipError) {
-      return next(changeMembershipError);
-    }
-    req.individualContext.webContext.saveUserAlert(`Downgraded ${username} from a team maintainer to a team member`, team2.name + ' membership updated', 'success');
-    refreshMaintainers(team2, refreshError => {
-      if (refreshError) {
-        return next(refreshError);
-      }
-      res.redirect(req.teamUrl);
-    });
-  });
-});
+  await team2.addMembership(username);
+  req.individualContext.webContext.saveUserAlert(`Downgraded ${username} from a team maintainer to a team member`, team2.name + ' membership updated', 'success');
+  const maintainers = await refreshMaintainers(team2);
+  res.redirect(req.teamUrl);
+}));
 
 router.use('/add', teamAdminRequired, (req: ILocalRequest, res, next) => {
   req.team2AddType = 'maintainer';
   return next();
 });
 
-router.post('/add', teamAdminRequired, function (req: ILocalRequest, res, next) {
-  const team2 = req.team2;
+router.post('/add', teamAdminRequired, asyncHandler(async function (req: ILocalRequest, res, next) {
+  const team2 = req.team2 as Team;
   const login = req.body.username;
-  team2.addMaintainer(login, (addMaintainerError) => {
-    if (addMaintainerError) {
-      return next(addMaintainerError);
-    }
-    req.individualContext.webContext.saveUserAlert(`Added ${login} as a team maintainer`, team2.name + ' membership updated', 'success');
-    refreshMaintainers(team2, refreshError => {
-      if (refreshError) {
-        return next(refreshError);
-      }
-      return res.redirect(req.teamUrl);
-    });
-  });
-});
+  await team2.addMaintainer(login);
+  req.individualContext.webContext.saveUserAlert(`Added ${login} as a team maintainer`, team2.name + ' membership updated', 'success');
+  const maintainers = await refreshMaintainers(team2);
+  return res.redirect(req.teamUrl);
+}));
 
 router.use('/add', require('../../peopleSearch'));
 

--- a/routes/org/team/members.ts
+++ b/routes/org/team/members.ts
@@ -18,7 +18,7 @@ const PeopleSearch = require('../../peopleSearch')
 const teamAdminRequired = require('./teamAdminRequired');
 
 interface ILocalTeamRequest extends ReposAppRequest {
-  team2?: any;
+  team2?: Team;
   refreshedMembers?: any;
   teamUrl?: any;
   team2AddType?: any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,8 @@
       "./routes/**/*",
       "./test/**/*",
       "./thirdparty/**/*",
+      "./github/**/*",
+      "./features/**/*",
       "./jobs/**/*",
       "./webhooks/**/*",
       "./app.ts",

--- a/views/email/newrepolockdown.pug
+++ b/views/email/newrepolockdown.pug
@@ -1,0 +1,79 @@
+//-
+//- Copyright (c) Microsoft. All rights reserved.
+//- Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-
+
+extends email
+
+block content
+
+  if isMailToCreator
+    p.
+      Hi,#[br]
+      You just created a new GitHub repository, #{lockdownMailContent.repository.name}. Complete the setup wizard to configure the repo permissions and release information.
+
+    if lockdownMailContent.repository && lockdownMailContent.repository.private
+      p
+        strong PRIVATE REPOSITORY NOTE:
+        br
+        | You created a new private repository. Your access to the repository will be restored once you complete the new repository wizard. Until then you will see a 404 Not Found HTTP error message.
+
+    h3 Gain access to your new repository
+    p
+      a(href=lockdownMailContent.linkToClassifyRepository, target='_new', style='font-size: 36px') Finish setting up #{lockdownMailContent.repository.name}
+      br
+      small
+        | Direct setup wizard link:
+        a(href=lockdownMailContent.linkToClassifyRepository, target='_new', style='font-size: 10px')= lockdownMailContent.linkToClassifyRepository
+
+    h4 Repository
+    p
+      a(href='https://github.com/' + lockdownMailContent.organization.name + '/' + lockdownMailContent.repository.name)= 'https://github.com/' + lockdownMailContent.organization.name + '/' + lockdownMailContent.repository.name
+      if lockdownMailContent.repository.private
+        br
+        | WARNING: This is a private repository and you will not be able to access it until you complete the setup process.
+
+    h4 GitHub user
+    if lockdownMailContent.link
+      table
+        tbody
+          tr
+            td GitHub account
+            td= lockdownMailContent.link.thirdPartyUsername
+          tr
+            td Corporate identity
+            td= lockdownMailContent.link.corporateUsername
+
+  else if isMailToOperations
+    p A repository was created directly on GitHub.com. The repository has been locked down pending the user's completion of the new repository wizard.
+
+    if mailSentToCreator
+      p A mail was sent to the person who created the repo to continue the process.
+    else
+      h2: strong WARNING no mail was sent to the creator.
+
+    h3 Created by #{lockdownMailContent.username}
+      p: a(href='https://github.com/' + lockdownMailContent.username)= 'https://github.com/' + lockdownMailContent.username
+    if lockdownMailContent.link
+      table
+        tbody
+          tr
+            td GitHub account
+            td= lockdownMailContent.link.thirdPartyUsername
+          tr
+            td Corporate identity
+            td= lockdownMailContent.link.corporateUsername
+
+    if lockdownMailContent.mailAddress
+      p
+        | Mail address of the user that created the account:&nbsp;
+        a(href='mailto:' + lockdownMailContent.mailAddress)= lockdownMailContent.mailAddress
+    else
+      p: strong An e-mail was NOT sent. No e-mail address was available for the username.
+
+    if lockdownMailContent.log
+      h3 Operations log
+      p The following lockdown operations log represents changes made from when the repo was created.
+      ul
+        each det in lockdownMailContent.log
+          li= det


### PR DESCRIPTION
To work around persistent GitHub bugs we have had the past few years related
to setting the member privilege level for many of our organizations to not
allow members to create repos, we are exploring this new opt-in only feature
flag called "direct new repo lockdown" that will help us to try and experiment
a way to allow our members to directly create repos.

The current prototyping design of this feature is:

1. if a repo is created by a GitHub App (a bot) or an approved system operations account, or the existing new repo workflow, no-op
2. if a repo is created by a member of the GitHub org, the repo is "locked down" - removing their collaborator and team permissions - and they are sent an e-mail asking them to complete the new repo setup by entering into our existing internal wizard for that.

The feature flag must be enabled in 2 places:

1. the app itself must opt in to the feature being available
2. an organization setting must opt in to the feature via configuration

This system requires a few specific parts of the monolithic app to
function: the use of a repository metadata provider (Postgres is what
we are using) to store additional source-of-truth data for a repo,
and also connecting to webhooks either through an org-level webhook
or a GitHub App that has a configured hook.