### PR TITLE
Update witness port default

### DIFF
--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -271,7 +271,7 @@ module.exports = function init(app: Application, express, rootdir, config, confi
         servername: wr.tls,
       };
     }
-    wr.port = wr.port || wr.tls ? 6380 : 6379;
+    wr.port = wr.port || (wr.tls ? 6380 : 6379);
     if (!wr.host && !wr.tls) {
       if (nodeEnvironment === 'production') {
         console.warn('Redis host or TLS host must be provided in production environments');


### PR DESCRIPTION
The conditional logic to determine wr port was overridden to 6380

`wr = {}`
> Object {  }
`wr.port = 6379`
> 6379
`wr.tls = undefined`
> undefined
`wr.port = wr.port || (wr.tls ? 6380 : 6379);`
> 6379
`wr.port = wr.port || wr.tls ? 6380 : 6379;`
> 6380
```