### PR TITLE
bugfix: membership publicize

### DIFF
--- a/business/organization.ts
+++ b/business/organization.ts
@@ -738,7 +738,7 @@ export class Organization {
       username: login,
     };
     try {
-      const ok = await operations.github.post(`token ${userToken}`, 'orgs.publicizeMembership', parameters);
+      await operations.github.post(`token ${userToken}`, 'orgs.publicizeMembership', parameters);
     } catch (error) {
       throw wrapError(error, `Could not publicize the ${this.name} organization membership for  ${login}: ${error.message}`);
     }

--- a/routes/org/membership.ts
+++ b/routes/org/membership.ts
@@ -8,9 +8,10 @@ import asyncHandler from 'express-async-handler';
 
 import { ReposAppRequest } from '../../transitional';
 import { wrapError } from '../../utils';
+import RequireActiveGitHubSession from '../../middleware/github/requireActiveSession';
 const router = express.Router();
 
-router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
+router.get('/', RequireActiveGitHubSession, asyncHandler(async function (req: ReposAppRequest, res, next) {
   const organization = req.organization;
   if (!organization) {
     // TODO: Was this ever a possible situation? What's going on here? Probably was v1 (single-org)
@@ -46,7 +47,7 @@ router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
   });
 }));
 
-router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
+router.post('/', RequireActiveGitHubSession, asyncHandler(async function (req: ReposAppRequest, res, next) {
   const username = req.individualContext.getGitHubIdentity().username;
   const organization = req.organization;
   if (!organization) {

--- a/views/org/publicMembershipStatus.pug
+++ b/views/org/publicMembershipStatus.pug
@@ -42,7 +42,7 @@ block content
         a.btn.btn-primary.btn-lg(href='/signin/github/increased-scope') Publish Membership
         if (!(onboarding || joining))
           | &nbsp; &nbsp;
-          a.btn.btn-default(href=organization.baseUrl) Cancel
+          a.btn.btn-lg.btn-default(href=organization.baseUrl) Cancel
 
       if onboarding || joining
         p.lead Manual way


### PR DESCRIPTION
The publicize/conceal operation on a GitHub organization requires an
active GitHub user session including an enhanced write-scoped token.

In the original OAuth world, this required a new OAuth dance; however,
with a GitHub App, we just need the token available. Adding the existing
middleware to require an active GitHub session for the membership page
helps achieve this.

Kudos to @wbsmolen for the bug report in #123 