### PR TITLE
New repo emails: notify the manager

### DIFF
--- a/business/operations.ts
+++ b/business/operations.ts
@@ -1159,7 +1159,7 @@ export class Operations {
     }
     return GetAddressFromUpnAsync(this.mailAddressProvider, corporateUsername);
   }
-
+  
   async getLinkWithOverhead(id: string, options?): Promise<ICorporateLink> {
     // TODO: remove function?
     console.log('* * * * * * * * * * * * /sd/sd/sd/sd/sd/sd getLinkWithOverhead * * * * * * * * * * * * * * * * * * * * ');

--- a/config/mail.json
+++ b/config/mail.json
@@ -14,5 +14,16 @@
       "user": "env://MAIL_SMTP_USER",
       "pass": "env://MAIL_SMTP_PASS"
     }
+  },
+  "directoryMailService": {
+    "clientId": "env://DIRECTORY_MAIL_SERVICE_CLIENTID",
+    "clientSecret": "env://DIRECTORY_MAIL_SERVICE_CLIENTSECRET",
+    "authority": "env://DIRECTORY_MAIL_SERVICE_AUTHORITY",
+    "resource": "env://DIRECTORY_MAIL_SERVICE_RESOURCE",
+    "publisherName": "env://DIRECTORY_MAIL_SERVICE_PUBLISHERNAME",
+    "eventName": "env://DIRECTORY_MAIL_SERVICE_EVENTNAME",
+    "senderProfile": "env://DIRECTORY_MAIL_SERVICE_SENDERPROFILE",
+    "replyTo": "env://DIRECTORY_MAIL_SERVICE_REPLYTO",
+    "appName": "env://DIRECTORY_MAIL_SERVICE_APPNAME"
   }
 }

--- a/jobs/managers/task.ts
+++ b/jobs/managers/task.ts
@@ -16,6 +16,7 @@ import { ICorporateLink } from '../../business/corporateLink';
 import { ICachedEmployeeInformation, RedisPrefixManagerInfoCache } from '../../business/operations';
 import { sleep } from '../../utils';
 import { IMicrosoftIdentityServiceBasics } from '../../lib/corporateContactProvider';
+import { getUserAndManager } from '../../lib/graphProvider/microsoftGraphProvider';
 
 export default async function refresh({ providers }: IReposJob) : Promise<IReposJobResult> {
   const graphProvider = providers.graphProvider;
@@ -178,15 +179,4 @@ export default async function refresh({ providers }: IReposJob) : Promise<IRepos
       errors,
     }
   };
-}
-
-async function getUserAndManager(graphProvider, employeeDirectoryId: string): Promise<any> {
-  return new Promise<any>((resolve, reject) => {
-    graphProvider.getUserAndManagerById(employeeDirectoryId, (err, info) => {
-      if (err) {
-        return reject(err);
-      }
-      return resolve(info);
-    });
-  });
 }

--- a/lib/graphProvider/microsoftGraphProvider.ts
+++ b/lib/graphProvider/microsoftGraphProvider.ts
@@ -216,3 +216,14 @@ export class MicrosoftGraphProvider implements IGraphProvider {
     });
   }
 }
+
+export function getUserAndManager(graphProvider, employeeDirectoryId: string): Promise<any> {
+  return new Promise<any>((resolve, reject) => {
+    graphProvider.getUserAndManagerById(employeeDirectoryId, (err, info) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(info);
+    });
+  });
+}

--- a/lib/mailProvider/customMailService.ts
+++ b/lib/mailProvider/customMailService.ts
@@ -1,10 +1,9 @@
 //
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-// customMailService.js: THIS FILE IS FOR INTERNAL USE AND SHOULD NOT BE OPEN SOURCED AT THIS TIME
-
-'use strict';
+// This file uses a Microsoft-specific internal mail system that will not be very useful to others.
 
 import request = require('request');
 import { IMailProvider, IMail } from '.';
@@ -35,6 +34,8 @@ export default class IrisMailService implements IMailProvider {
     this.info = `customMailService-${customServiceConfig.version} v${appVersion}`;
     this._config = config;
   }
+
+  async initialize() {}
 
   async sendMail(mail: IMail): Promise<any> {
     const mailConfig = this._config.mail;
@@ -89,6 +90,7 @@ export default class IrisMailService implements IMailProvider {
       customMailPost.mail['category'] = category;
     }
     await new Promise((resolve, reject) => {
+      console.dir(customMailPost);
       request.post({
         auth,
         json: true,

--- a/lib/mailProvider/directoryMailService.ts
+++ b/lib/mailProvider/directoryMailService.ts
@@ -1,0 +1,274 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+// This file uses a Microsoft-specific internal mail system that will not be very useful to others.
+
+import * as adalNode from 'adal-node';
+import { v4 } from 'uuid';
+
+import appPackage = require('../../package.json');
+
+const request = require('requestretry').defaults({ json: true, maxAttempts: 3, fullResponse: true });
+
+import { IMailProvider, IMail } from '.';
+import { IDictionary } from '../../transitional';
+
+function pop(obj, key) {
+  const val = obj[key];
+  delete obj[key];
+  return val;
+}
+
+const directoryClientVersion = '1.0.0';
+
+export interface IDirectoryMailServiceOptions {
+  appName: string;
+  clientId: string;
+  clientSecret: string;
+  authority: string;
+  resource: string;
+  publisherName: string;
+  eventName: string;
+  senderProfile: string;
+  replyTo?: string;
+}
+
+const requiredProperties = [
+  'appName',
+  'clientId',
+  'clientSecret',
+  'authority',
+  'resource',
+  'publisherName',
+  'eventName',
+  'senderProfile',
+  // replyTo: optional
+];
+
+const uninterestingHeaders = [
+  'connection',
+  'date',
+  'content-length',
+  'client-request-id',
+];
+
+interface IDirectoryMailResult {
+  requestId: string;
+  headers: IDictionary<string>;
+}
+
+export default class DirectoryMailService implements IMailProvider {
+  private static readonly maxTokenAge: number = 1000 * 10; // 10 seconds
+  private directoryTokenLastSet: number;
+  private directoryToken: string;
+
+  #options: IDirectoryMailServiceOptions;
+
+  html: true;
+  info: string;
+
+  getSentMessages() {
+    return []; // this provider does not support in-project testing
+  }
+
+  constructor(directoryMailOptions: IDirectoryMailServiceOptions) {
+    for (const property of requiredProperties) {
+      if (!directoryMailOptions[property]) {
+        throw new Error(`directoryMailOptions.${property} is required`);
+      }
+    };
+    this.#options = directoryMailOptions;
+    const { version } = appPackage;
+    this.info = `${directoryMailOptions.appName}-${directoryClientVersion} v${version}`;
+  }
+
+  async initialize() {
+    const pingEvent = new DirectoryMailServiceMessage('Ping');
+    const { headers } = await this.sendToService(pingEvent);
+    const headerNames = Object.getOwnPropertyNames(headers).filter(name => !uninterestingHeaders.includes(name));
+    return headerNames.map(name => `${name}=${headers[name]}`).join(' ');
+  }
+
+  async sendMail(mail: IMail): Promise<any> {
+    let replyTo: string | string[] = this.#options.replyTo;
+    let to = pop(mail, 'to');
+    if (!to) {
+      throw new Error('The e-mail must have a recipient.');
+    }
+    if (typeof to === 'string') {
+      to = [ to ];
+    }
+    const subject = pop(mail, 'subject');
+    if (!subject) {
+      throw new Error('The e-mail must have a subject.');
+    }
+    const content = pop(mail, 'content');
+    if (!content) {
+      throw new Error('A message must include content.');
+    }
+    let cc = pop(mail, 'cc');
+    if (cc && typeof cc === 'string') {
+      cc = [ cc ];
+    }
+    let bcc = pop(mail, 'bcc');
+    if (bcc && typeof bcc === 'string') {
+      bcc = [ bcc ];
+    }
+    if (replyTo && typeof replyTo === 'string') {
+      replyTo = [ replyTo ];
+    }
+    const correlationId = pop(mail, 'correlationId');
+    cc = cc || [];
+    bcc = bcc || [];
+    const html = content;
+    const text = null;
+    // ...
+    const message = new DirectoryMailServiceMessage(this.#options.eventName);
+    message.SenderProfile = this.#options.senderProfile;
+    const source = html ? {
+      KeyValuePairs: {
+        Subject: subject,
+        HtmlBody: html,
+      },
+      SourceType: 'Inline',
+    } : {
+      KeyValuePairs: {
+        Subject: subject,
+        PlainTextBody: text,
+      },
+      SourceType: 'Inline',
+    };
+    message.Configuration = {
+      Deliveries: [{
+        DeliveryType: 'Email',
+        Engine: { EngineType: 'PassThrough' },
+        Source: source,
+        TopicId: null,
+        Validity: null
+      }],
+      RealTime: false,
+      CampaignInjectionId: null,
+      SkipProfile: true,
+    };
+    message.Recipients = {
+      To: this.mapRecipientToSpecializedFormat(to),
+      Cc: this.mapRecipientToSpecializedFormat(cc),
+      Bcc: this.mapRecipientToSpecializedFormat(bcc),
+      ReplyTo: this.mapRecipientToSpecializedFormat(replyTo as string[]),
+    };
+
+    try {
+      const receipt = await this.sendToService(message);
+      return receipt.requestId;
+    } catch (sendError) {
+      console.dir(sendError);
+      throw sendError;
+    }
+  }
+
+  private async sendToService(body: DirectoryMailServiceMessage): Promise<IDirectoryMailResult> {
+    const requestId = v4();
+    try {
+      const token = await this.getDirectoryToken();
+      const publisherName = this.#options.publisherName;
+      const authHeaderValue = `Partner partner_id="${publisherName}", bearer_token="${token}"`;
+      const url = `${this.#options.resource}events/v1/trigger`;
+      const options = {
+        url,
+        headers: {
+          'Content-Type': 'application/vnd.ms.services.mucp.event.v1+json; charset=utf-8',
+          'client-request-id': requestId,
+          'return-client-request-id': 'True',
+          'User-Agent': this.info,
+          'Authorization': authHeaderValue,
+        },
+        body,
+      };
+      return await new Promise((resolve, reject) => {
+        return request.post(options, (err: Error, response: any, responseBody: any) => {
+          if (!err && response) {
+            if (response.statusCode === 401) {
+              err = new Error(`Not authorized to connect to the directory mail service with publisherName=${publisherName}, clientId=${this.#options.clientId}`);
+            } else if (response.statusCode !== 202) {
+              err = new Error(`statusCode=${response.statusCode} returned trying to send to the directory mail service with clientId=${this.#options.clientId}`);
+            }
+          }
+          if (err) {
+            err['client-request-id'] = requestId;
+            return reject(err);
+          }
+          return resolve({ headers: response.headers, requestId });
+        });
+      });
+    } catch (error) {
+      error['client-request-id'] = requestId;
+      throw error;
+    }
+  }
+
+  private getDirectoryToken(): Promise<string> {
+    const now = (new Date()).getTime();
+    const tokenTime = this.directoryTokenLastSet || 0;
+    const allowedMax = tokenTime + DirectoryMailService.maxTokenAge;
+    return new Promise((resolve, reject) => {
+      if (this.directoryToken && now <= allowedMax) {
+        return resolve(this.directoryToken);
+      }
+      const context = new adalNode.AuthenticationContext(this.#options.authority);
+      context.acquireTokenWithClientCredentials(this.#options.resource, this.#options.clientId, this.#options.clientSecret, (tokenAcquisitionError, tokenResponse) => {
+        if (tokenAcquisitionError) {
+          return reject(tokenAcquisitionError);
+        }
+        const authorizationValue = (tokenResponse as adalNode.TokenResponse).accessToken;
+        this.directoryToken = authorizationValue;
+        this.directoryTokenLastSet = now;
+        return resolve(authorizationValue);
+      });
+    });
+  }
+
+  private mapRecipientToSpecializedFormat(recipients: string[]) {
+    if (recipients && Array.isArray(recipients) && recipients.length > 0) {
+      return recipients.map(rec => {
+        return {
+          Format: 1, // hard-coded C#/.NET enum from a specific SDK
+          Value: rec,
+        };
+      });
+    } else {
+      return null;
+    }
+  }
+}
+
+class DirectoryMailServiceMessage {
+  public EventName: string;
+  public InstanceId: string;
+  public Recipients: any = null;
+  public Attachments: any = null;
+  public LinkedAttachments: any = null;
+  public Puid: string = null;
+  public Locale: string = null;
+  public Properties: any = null;
+  public Date: string = null;
+  public Targeting: string = null;
+  public Configuration: any = null;
+  public Delay: any = null;
+  public SenderProfile: any = null;
+  public NotAfter: any = null;
+  public CommercialIdentity: any = null;
+
+  constructor(eventName: string) {
+    this.InstanceId = v4();
+    this.EventName = eventName;
+  }
+
+  getInstrumentationDetails(): any {
+    return {
+      eventName: this.EventName,
+      instanceId: this.InstanceId
+    };
+  }
+}

--- a/lib/mailProvider/index.ts
+++ b/lib/mailProvider/index.ts
@@ -3,11 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import MockMailService from './mockMailService';
 import IrisMailService from './customMailService';
 import SmtpMailService from './smtpMailService';
+import DirectoryMailService from './directoryMailService';
 
 export interface IMail {
   from?: string;
@@ -25,6 +24,7 @@ export interface IMailProvider {
   sendMail(mail: IMail): Promise<any>;
   html: boolean;
   getSentMessages(): any[];
+  initialize(): Promise<string | void>;
 }
 
 function patchOverride(provider, newToAddress, htmlOrNot) {
@@ -81,6 +81,10 @@ export default function createMailProviderInstance(config): IMailProvider {
     }
     case 'smtpMailService': {
       mailProvider = new SmtpMailService(config);
+      break;
+    }
+    case 'directory': {
+      mailProvider = new DirectoryMailService(config.mail?.directoryMailService);
       break;
     }
     case 'mockMailService': {

--- a/lib/mailProvider/mockMailService.ts
+++ b/lib/mailProvider/mockMailService.ts
@@ -21,6 +21,8 @@ export default class MockMailService implements IMailProvider {
     this.appVersion = config.logging.version;
   }
 
+  async initialize() {}
+  
   get info(): string {
     return `mockMailService-${this.customServiceConfig.version} v${this.appVersion}`;
   }

--- a/lib/mailProvider/smtpMailService.ts
+++ b/lib/mailProvider/smtpMailService.ts
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import { IMailProvider, IMail } from ".";
 
 const nodemailer = require('nodemailer');
@@ -22,6 +20,8 @@ export default class SmtpMailService implements IMailProvider {
   getSentMessages() {
     return []; // this provider does not support mocks
   }
+
+  async initialize() {}
 
   async sendMail(mail: IMail): Promise<any> {
     if (!this._config.customSmtpService) {

--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -98,8 +98,10 @@ async function initializeAsync(app: IReposApplication, express, rootdir: string,
   providers.mailAddressProvider = await createMailAddressProvider(config, providers);
   app.set('mailAddressProvider', providers.mailAddressProvider);
 
-  providers.mailProvider = CreateMailProviderInstance(config);
-  app.set('mailProvider', providers.mailProvider); // necessry anymore? hopefully not!
+  const mailProvider = CreateMailProviderInstance(config);
+  const mailInitializedMessage = await mailProvider.initialize();
+  debug(`mail provider type=${config.mail.provider} ${mailInitializedMessage}`);
+  providers.mailProvider = mailProvider;
 
   providers.github = await configureGitHubLibrary(app, providers.cacheProvider, providers.linkProvider, config);
   app.set('github', providers.github);

--- a/middleware/staticClientApp.ts
+++ b/middleware/staticClientApp.ts
@@ -5,8 +5,6 @@
 
 /*eslint no-console: ["error", { allow: ["log", "error", "warn", "dir"] }] */
 
-'use strict';
-
 import appPackage = require('../package.json');
 const packageVariableName = 'static-client-package-name';
 

--- a/middleware/staticSiteAssets.ts
+++ b/middleware/staticSiteAssets.ts
@@ -5,8 +5,6 @@
 
 /*eslint no-console: ["error", { allow: ["log", "error", "warn", "dir"] }] */
 
-'use strict';
-
 import appPackage = require('../package.json');
 
 const debug = require('debug')('startup');

--- a/pg.sql
+++ b/pg.sql
@@ -48,12 +48,12 @@ CREATE INDEX IF NOT EXISTS events_repoid ON events ((metadata->>'repositoryid'))
 CREATE INDEX IF NOT EXISTS events_orgid ON events ((metadata->>'organizationid'));
 CREATE INDEX IF NOT EXISTS events_userid ON events ((metadata->>'userid'));
 CREATE INDEX IF NOT EXISTS events_usercorporateid ON events ((metadata->>'usercorporateid'));
-CREATE INDEX IF NOT EXISTS events_orgname ON events ((metadata->>'organizationname'))
-CREATE INDEX IF NOT EXISTS events_open_range1 ON events((metadata->'additionaldata'->>'contribution'), (metadata->'created'))
-CREATE INDEX IF NOT EXISTS events_open_range2 ON events((metadata->'userid'), (metadata->'additionaldata'->>'contribution'), (metadata->'created'))
-CREATE INDEX IF NOT EXISTS events_open_range3 ON events((metadata->'usercorporateid'), (metadata->'additionaldata'->>'contribution'), (metadata->'created'))
-CREATE INDEX IF NOT EXISTS events_open_range4 ON events((metadata->'usercorporateid'), (metadata->'created'))
-CREATE INDEX IF NOT EXISTS events_open_range5 ON events((metadata->'additionaldata'->>'contribution'))
+CREATE INDEX IF NOT EXISTS events_orgname ON events ((metadata->>'organizationname'));
+CREATE INDEX IF NOT EXISTS events_open_range1 ON events((metadata->'additionaldata'->>'contribution'), (metadata->'created'));
+CREATE INDEX IF NOT EXISTS events_open_range2 ON events((metadata->'userid'), (metadata->'additionaldata'->>'contribution'), (metadata->'created'));
+CREATE INDEX IF NOT EXISTS events_open_range3 ON events((metadata->'usercorporateid'), (metadata->'additionaldata'->>'contribution'), (metadata->'created'));
+CREATE INDEX IF NOT EXISTS events_open_range4 ON events((metadata->'usercorporateid'), (metadata->'created'));
+CREATE INDEX IF NOT EXISTS events_open_range5 ON events((metadata->'additionaldata'->>'contribution'));
 
 CREATE INDEX IF NOT EXISTS events_c_usercorporateid ON events (usercorporateid);
 CREATE INDEX IF NOT EXISTS events_c_isopencontribution ON events (isopencontribution);

--- a/routes/api/client/newOrgRepo.ts
+++ b/routes/api/client/newOrgRepo.ts
@@ -3,12 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express = require('express');
 import asyncHandler from 'express-async-handler';
+const router = express.Router();
 
 import _ from 'lodash';
+
 import { ReposAppRequest, IProviders } from '../../../transitional';
 import { jsonError } from '../../../middleware/jsonError';
 import { IndividualContext } from '../../../user';
@@ -17,8 +17,6 @@ import { CreateRepository, ICreateRepositoryApiResult } from '../createRepo';
 import { Team, GitHubTeamRole } from '../../../business/team';
 import { GetAddressFromUpnAsync } from '../../../lib/mailAddressProvider';
 import { asNumber } from '../../../utils';
-
-const router = express.Router();
 
 interface ILocalApiRequest extends ReposAppRequest {
   apiVersion?: string;

--- a/routes/api/client/newRepo.ts
+++ b/routes/api/client/newRepo.ts
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express = require('express');
 import { ReposAppRequest } from '../../../transitional';
 import { jsonError } from '../../../middleware/jsonError';

--- a/routes/org/team/index.ts
+++ b/routes/org/team/index.ts
@@ -138,7 +138,7 @@ router.post('/join', asyncHandler(async (req: ILocalRequest, res, next) => {
   if (req.existingRequest) {
     throw new Error('You have already created a team join request that is pending a decision.');
   }
-  const config = req.app.settings.runtimeConfig;
+  const { config, mailProvider } = req.app.settings.providers as IProviders;
   const organization = req.organization as Organization;
   const operations = req.app.settings.providers.operations as Operations;
   const team2 = req.team2 as Team;
@@ -173,7 +173,6 @@ router.post('/join', asyncHandler(async (req: ILocalRequest, res, next) => {
     });
     return res.redirect(`${organization.baseUrl}teams`);
   }
-
   const justification = req.body.justification;
   if (justification === undefined || justification === '') {
     return next(wrapError(null, 'You must include justification for your request.', true));
@@ -187,7 +186,6 @@ router.post('/join', asyncHandler(async (req: ILocalRequest, res, next) => {
   if (!mailProviderInUse) {
     return next(new Error('No configured approval providers configured.'));
   }
-  const mailProvider = req.app.settings.mailProvider;
   const approverMailAddresses = [];
   if (mailProviderInUse && !mailProvider) {
     return next(wrapError(null, 'No mail provider is enabled, yet this application is configured to use a mail provider.'));

--- a/views/email/repoApprovals/autoCreated.pug
+++ b/views/email/repoApprovals/autoCreated.pug
@@ -74,3 +74,8 @@ block content
       each result in results
         if result && (result.error || result.message)
           li(style=result.error ? 'color:red' : undefined)= result.message
+
+  if managerInfo && managerInfo.managerMail
+    h3 Additional notifications
+    p For visibility, the manager #{managerMail.managerDisplayName ? managerMail.managerDisplayName : managerMail.managerMail} was also notified of this new GitHub repo for open source.
+    


### PR DESCRIPTION
If a manager is known for an employee, we will also notify
the manager via a carbon copy on e-mails related to new repos,
locked forks, or newly created repos that still need classification.

As a quick change, this does not add a feature flag to enable or disable
this; however, if a manager is not known via the corporate contacts or
cached employee information system, there will be no error.

Also adds a new `directory mail provider` that integrates with a slightly
different email service we have been using. The new provider type name
is 'directory', but it is not standard in the app, just opt-in.