### PR TITLE
New feature: self-service team maintainer upgrade

### DIFF
--- a/business/team.ts
+++ b/business/team.ts
@@ -175,6 +175,14 @@ export class Team {
     return operations.baseUrl + 'teams?q=' + this._id;
   }
 
+  get nativeUrl() {
+    if (this._organization && this._slug) {
+      return this._organization.nativeManagementUrl + `teams/${this._slug}/`;
+    }
+    // Less ideal fallback
+    return this._organization.nativeManagementUrl + `teams/`;
+  }
+
   async ensureName(): Promise<void> {
     if (this._name && this._slug) {
       return;

--- a/config/features.json
+++ b/config/features.json
@@ -1,4 +1,5 @@
 {
+  "allowTeamMemberToMaintainerSelfUpgrades": "env://FEATURE_FLAG_ALLOW_TEAM_MEMBERTOMAINTAINER_UPGRADES?trueIf=1",
   "allowUnauthorizedNewRepositoryLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_NEW_REPOSITORY_LOCKDOWN_SYSTEM?trueIf=1",
   "allowUnauthorizedForkLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_FORK_LOCKDOWN_SYSTEM?trueIf=1",
   "allowUnauthorizedTransferLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_TRANSFER_LOCKDOWN_SYSTEM?trueIf=1",

--- a/config/github.teams.json
+++ b/config/github.teams.json
@@ -1,0 +1,4 @@
+{
+  "maximumMembersToAllowUpgrade": "env://GITHUB_SELFSERVICE_TEAM_MEMBERTOMAINTAINER_MAXIMUM_MEMBER_COUNT?default=20",
+  "maximumMaintainersToAllowUpgrade": "env://GITHUB_SELFSERVICE_TEAM_MEMBERTOMAINTAINER_MAXIMUM_MAINTAINER_COUNT?default=1"
+}

--- a/features/teamMemberToMaintainerUpgrade.ts
+++ b/features/teamMemberToMaintainerUpgrade.ts
@@ -1,0 +1,170 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { Team, GitHubTeamRole, ITeamMembershipRoleState } from '../business/team';
+import { Operations } from '../business/operations';
+import { IndividualContext } from '../user';
+import { NoRestApiCache, ErrorHelper } from '../transitional';
+import { asNumber, addArrayToSet } from '../utils';
+import { IMail } from '../lib/mailProvider';
+import { OrganizationMembershipState } from '../business/organization';
+
+interface ISelfServiceAllowedResult {
+  currentMaintainerCount: number;
+  currentMemberCount: number;
+}
+
+export interface ISelfServiceTeamMemberToMaintainerUpgradeOptions {
+  operations: Operations;
+  team: Team;
+}
+
+export default class SelfServiceTeamMemberToMaintainerUpgrades {
+  #team: Team;
+  #operations: Operations;
+
+  constructor(options: ISelfServiceTeamMemberToMaintainerUpgradeOptions) {
+    if (!options.operations || !options.team) {
+      throw new Error('options.operations and options.team are required');
+    }
+    this.#operations = options.operations;
+    this.#team = options.team;
+  }
+
+  isSelfServiceUpgradeEnabled(): boolean {
+    return this.#operations.allowSelfServiceTeamMemberToMaintainerUpgrades();
+  }
+
+  maximimumAllowedMembers(): number {
+    const value = this.#operations.config.github?.teams?.maximumMembersToAllowUpgrade;
+    return value ? asNumber(value) : 0;
+  }
+
+  maximumAllowedMaintainers(): number {
+    const value = this.#operations.config.github?.teams?.maximumMaintainersToAllowUpgrade;
+    return value ? asNumber(value) : 0;
+  }
+
+  async isTeamEligible(cacheOk?: boolean): Promise<ISelfServiceAllowedResult | string> {
+    const cacheOptions = cacheOk ? {} : NoRestApiCache;
+    const team = this.#team;
+    const maintainersCount = (await team.getMaintainers(cacheOptions)).length;
+    if (maintainersCount > this.maximumAllowedMaintainers()) {
+      return `There are currently ${maintainersCount} maintainers of the team. Self-service upgrade is only available if there are ${this.maximumAllowedMaintainers()} or fewer maintainers.`;
+    }
+    const membersCount = (await team.getMembers(cacheOptions)).length;
+    if (membersCount > this.maximimumAllowedMembers()) {
+      return `There are currently ${membersCount} members of the team. Self-service upgrade is only available if there are ${this.maximimumAllowedMembers()} or fewer members.`;
+    }
+    return { currentMaintainerCount: maintainersCount, currentMemberCount: membersCount };
+  }
+
+  async isUserTeamMember(login: string): Promise<boolean> {
+    const membership = await this.#team.getMembership(login, NoRestApiCache) as ITeamMembershipRoleState;
+    return (membership.state === OrganizationMembershipState.Active && membership.role === GitHubTeamRole.Member);
+  }
+
+  async validateUserCanSelfServicePromote(individualContext: IndividualContext): Promise<ISelfServiceAllowedResult> {
+    if (!this.isSelfServiceUpgradeEnabled()) {
+      throw new Error('Self-service upgrade is not available');
+    }
+    if (!individualContext.corporateIdentity || !individualContext.corporateIdentity.id || !individualContext.getGitHubIdentity().id) {
+      throw new Error('The authenticated user is not properly linked');
+    }
+    const login = individualContext.getGitHubIdentity().username;
+    const teamEligiblityResult: ISelfServiceAllowedResult | string = await this.isTeamEligible();
+    if (typeof(teamEligiblityResult) === 'string') {
+      throw new Error(teamEligiblityResult as string);
+    }
+    const userIsTeamMember = await this.isUserTeamMember(login);
+    if (!userIsTeamMember) {
+      throw new Error('The user is not a member of the team and so cannot be upgraded');
+    }
+    return teamEligiblityResult as ISelfServiceAllowedResult;
+  }
+
+  async upgrade(individualContext: IndividualContext): Promise<void> {
+    const team = this.#team;
+    const operations = this.#operations;
+    await team.getDetails();
+    const canUpgradeDetails = await this.validateUserCanSelfServicePromote(individualContext);
+    const login = individualContext.getGitHubIdentity().username;
+    const { queryCache } = operations.providers;
+    try {
+      await team.addMaintainer(login);
+      if (queryCache && queryCache.supportsTeamMembership) {
+        try {
+          await queryCache.addOrUpdateTeamMember(
+            String(team.organization.id),
+            String(team.id),
+            String(individualContext.getGitHubIdentity().id),
+            GitHubTeamRole.Maintainer,
+            login,
+            individualContext.getGitHubIdentity().avatar);
+        } catch (ignoreQueryCacheUpdateError) {
+          console.log('ignoreQueryCacheUpdateError:');
+          console.warn(ignoreQueryCacheUpdateError);
+        }
+      }
+    } catch (upgradeError) {
+      throw ErrorHelper.WrapError(upgradeError, `Self-service team maintainer upgrade for the GitHub account ${login} in the ${team.organization.name} org team ${team.name} failed: ${upgradeError}`);
+    }
+    // Refresh for display
+    try {
+      await team.getMaintainers(NoRestApiCache);
+    } catch (ignoreTeamRefreshErrors) {
+      console.log('ignoreTeamRefreshErrors:');
+      console.warn(ignoreTeamRefreshErrors);
+    }
+    // Send a notification mail to many folks... with this logic:
+    // If the Team Maintainer count before the upgrade was > 0, just notify the current team maintainers.
+    // Otherwise, notify all Team Members of the upgrade.
+    try {
+      const maintainers = await team.getMaintainers();
+      const idsToNotify = new Set<string>(maintainers.map(maintainer => String(maintainer.id)));
+      let notifyDescription = `All of the Team Maintainers for the ${team.name} team are being notified in this mail.`;
+      if (canUpgradeDetails.currentMaintainerCount === 0) {
+        const members = await team.getMembers();
+        addArrayToSet(idsToNotify, members.map(member => String(member.id)));
+        notifyDescription = `All of the Team Members and Team Maintainers for the ${team.name} team are being notified in this mail.`;
+      }
+      const links = await operations.getLinksFromThirdPartyIds(Array.from(idsToNotify.values()));
+      const thirdPartyLoginToLink = new Map();
+      links.map(userLink => {
+        const login = userLink.thirdPartyUsername.toLowerCase();
+        thirdPartyLoginToLink.set(login, userLink);
+      });
+      const mailAddresses = await operations.getMailAddressesFromCorporateUsernames(links.map(link => link.corporateUsername));
+      const opsAddress = operations.getOperationsMailAddress();
+      const companyName = operations.config.brand.companyName;
+      const identifierForRequester = individualContext.corporateIdentity.displayName || individualContext.corporateIdentity.username;
+      const mail: IMail = {
+        to: mailAddresses,
+        cc: opsAddress ? [opsAddress] : null,
+        subject: `${team.organization.name}/${team.name}: GitHub Team Member ${identifierForRequester} upgraded themselves to Team Maintainer`,
+        content: await operations.emailRender('teamMemberSelfServiceMaintainerUpgrade', {
+          reason: (`This is a required operational notification: ${identifierForRequester} used a self-service permission upgrade feature. ${notifyDescription}`),
+          headline: `Team maintainer upgrade`,
+          notification: 'information',
+          app: `${companyName} GitHub`,
+          team,
+          link: individualContext.link,
+          organization: team.organization,
+          identifierForRequester,
+          maintainers,
+          thirdPartyLoginToLink,
+        }),
+      };
+      await this.#operations.sendMail(mail);
+    } catch (mailError) {
+      console.log('mailError:');
+      console.warn(mailError);
+    }
+    const insights = this.#operations.insights;
+    if (insights) {
+      insights.trackMetric({ name: 'TeamSelfServiceMemberToMaintainerUpgrades', value: 1 });
+    }
+  }
+}

--- a/jobs/reports/organizations.ts
+++ b/jobs/reports/organizations.ts
@@ -13,6 +13,7 @@ import { requireJson, asNumber } from '../../utils';
 import { OrganizationMember } from '../../business/organizationMember';
 import { IReportsContext } from './task';
 import { ICorporateLink } from '../../business/corporateLink';
+import { NoRestApiCache } from '../../transitional';
 
 const definitions = requireJson('jobs/reports/organizationDefinitions.json');
 
@@ -79,13 +80,11 @@ function getIndividualUserLink(context: IReportsContext, id: number): Promise<IC
 }
 
 async function ensureAllUserLinks(context: IReportsContext, operations: Operations) {
-  const latestDataOptions = {
+  const latestDataOptions = Object.assign({
     includeNames: true,
     includeId: true,
     includeServiceAccounts: true,
-    maxAgeSeconds: 0,
-    backgroundRefresh: false,
-  };
+  }, NoRestApiCache);
   const links = await operations.getLinks(latestDataOptions);
   const set = new Map<number, ICorporateLink>();
   for (let i = 0; i < links.length; i++) {

--- a/routes/org/2fa.ts
+++ b/routes/org/2fa.ts
@@ -3,15 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express = require('express');
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
 import moment from 'moment';
 
-import { ReposAppRequest } from '../../transitional';
+import { ReposAppRequest, NoRestApiCache } from '../../transitional';
 import { wrapError } from '../../utils';
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
@@ -21,12 +19,8 @@ router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
 
   req.individualContext.webContext.pushBreadcrumb('Multi-factor authentication check');
   const username = req.individualContext.getGitHubIdentity().username;
-  const cacheOptions = /* never use the cache */ {
-    backgroundRefresh: false,
-    maxAgeSeconds: -60,
-  };
   try {
-    const state = await organization.isMemberSingleFactor(username, cacheOptions);
+    const state = await organization.isMemberSingleFactor(username, NoRestApiCache);
     if (state === false && (req.body.validate || onboarding || joining)) {
       let url = organization.baseUrl;
       if (onboarding || joining) {

--- a/routes/org/team/maintainers.ts
+++ b/routes/org/team/maintainers.ts
@@ -9,7 +9,7 @@ import express = require('express');
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest } from '../../../transitional';
+import { ReposAppRequest, NoRestApiCache } from '../../../transitional';
 import { Team } from '../../../business/team';
 import { TeamMember } from '../../../business/teamMember';
 const teamAdminRequired = require('./teamAdminRequired');
@@ -32,10 +32,7 @@ router.use(asyncHandler(async (req: ILocalRequest, res, next) => {
 }));
 
 async function refreshMaintainers(team2: Team): Promise<TeamMember[]> {
-  return team2.getMaintainers({
-    maxAgeSeconds: -1,
-    backgroundRefresh: false,
-  });
+  return team2.getMaintainers(NoRestApiCache);
 }
 
 router.get('/refresh', (req: ILocalRequest, res) => {

--- a/routes/org/teams.ts
+++ b/routes/org/teams.ts
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express = require('express');
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
@@ -45,9 +43,6 @@ router.use('/:teamSlug', asyncHandler(async (req: ITeamsRequest, res, next) => {
   const slug = req.params.teamSlug as string;
   try {
     const team = await organization.getTeamFromName(slug);
-    // The `req.team` variable is currently used by the "legacy"
-    // operations system, so for the time being until there is more
-    // appropriate time for refactoring, this will have to do.
     req.team2 = team;
     // Breadcrumb and path updates
     req.teamUrl = `${orgBaseUrl}teams/${team.slug}/`;

--- a/transitional.ts
+++ b/transitional.ts
@@ -195,6 +195,11 @@ export interface InnerError extends Error {
   inner?: Error;
 }
 
+export const NoRestApiCache: ICacheOptions = {
+  backgroundRefresh: false,
+  maxAgeSeconds: -1,
+};
+
 export interface IReposError extends Error {
   skipLog?: boolean;
   status?: any; // status?: number;

--- a/views/email/teamMemberSelfServiceMaintainerUpgrade.pug
+++ b/views/email/teamMemberSelfServiceMaintainerUpgrade.pug
@@ -1,0 +1,51 @@
+//-
+//- Copyright (c) Microsoft.
+//- Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-
+
+extends email
+
+block content
+
+  p.
+    Hi,#[br]
+    #{identifierForRequester} has upgraded themselves to be Team Maintainer of a team that you are in:
+  ul
+    li Team name: #{team.name} #{team.name !== team.slug ? '(' + team.slug + ')' : ''}
+    li GitHub direct link: #[a(href=team.nativeUrl)= team.nativeUrl]
+    li Internal management and information link: #[a(href=team.baseUrl)= team.baseUrl]
+  
+  h3 About this operation
+  p.
+    This self-service operation is in Preview. We hope that this has been useful to help unblock you. 
+    More information about the #{team.name} team can be found at #{team.baseUrl}.
+
+  if link && link.thirdPartyUsername
+    h3 Requested created by #{identifierForRequester}
+      p: a(href='https://github.com/' + link.thirdPartyUsername)= 'https://github.com/' + link.thirdPartyUsername
+      if link
+        table
+          tbody
+            tr
+              td GitHub account
+              td= link.thirdPartyUsername
+            tr
+              td Corporate identity
+              td= link.corporateUsername
+
+  if maintainers && maintainers.length
+    h3 Team Maintainers
+    p Other team maintains include:
+    ul
+      each maintainer in maintainers
+        if maintainer.login
+          - var maintainerLink = thirdPartyLoginToLink.get(maintainer.login.toLowerCase())
+          li: p
+            if maintainerLink.corporateDisplayName
+              = 'Name: ' + maintainerLink.corporateDisplayName
+              br
+            if maintainerLink.corporateUsername
+              = 'Corporate identity: ' + maintainerLink.corporateDisplayName
+              br
+            if maintainerLink.thirdPartyUsername
+              = 'GitHub account: ' + maintainerLink.thirdPartyUsername

--- a/views/org/team/index.pug
+++ b/views/org/team/index.pug
@@ -10,7 +10,7 @@ extends ../../layout
 mixin authenticGitHubLink()
   ul.list-unstyled
     li: a.btn.btn-sm(
-          href='https://github.com/orgs/' + organization.name + '/teams/' + team2.slug,
+          href=team.nativeUrl,
           target="_blank",
           class=admin ? 'btn-primary' : 'btn-muted-more'
           )
@@ -151,7 +151,7 @@ block content
                 p Please check your e-mail for a message from GitHub asking you to accept your invitation to this team.
                 p You may also be able to accept your invitation on the team page at GitHub:
                 p: a.btn.btn-default.btn-sm(
-                  href='https://github.com/orgs/' + organization.name + '/teams/' + team2.slug,
+                  href=team2.nativeUrl,
                   target="_blank") Open team on GitHub.com
           //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           //- JOIN
@@ -210,23 +210,39 @@ block content
         if maintainers && display == 'default'
           h2
             = 'Team Maintainers '
-            small: a(href=teamUrl + 'maintainers/refresh', title='Refresh the team maintainers list')
+            small: a(href=teamUrl + 'maintainers/refresh', title='Refresh the team maintainers list. For performance reasons, this view may be cached.')
               i.glyphicon.glyphicon-refresh
 
           if maintainers.length <= 0
               div.alert.alert-danger(role='alert')
                 strong This team does not have any maintainers
                 br
-                | Without team maintainers members cannot request access to this team and it is unclear who the owner of the repository is.
+                | Without team maintainers people cannot request access to this team and it is unclear who the owner of any associated repositories is.
           else
             if maintainers.length < 2
-              div.alert.alert-warning(role='alert')
+              div.alert.alert-warning(role='alert', style='color: #000')
                 strong This team only has a single maintainer
                 br
                 | It is strongly recommended that a team have multiple maintainers to make it easier to stay on top of permission requests.
             +membersList('maintainer', maintainers, admin)
 
-          if admin
+          if isSelfServiceMemberToMaintainerEligible
+            .alert.alert-gray
+              h4 Self-service Maintainer Upgrade
+              p If you would like to take control of managing this team, you can choose to upgrade yourself to a Team Maintainer.
+              p: form(method='post', action=team.baseUrl + 'selfServiceMaintainerUpgrade')
+                ul.list-inline
+                  li: input.btn.btn-default.btn-sm(
+                    type='submit',
+                    onclick='return confirm(\'Are you sure that you would like to become the Team Maintainer? For awareness, this will inform other maintainers or members.\');',
+                    value='Upgrade to Team Maintainer')
+                  li: input.btn.btn-muted.btn-sm(
+                    style='margin-left:-12px',
+                    type='submit',
+                    onclick='return confirm(\'Are you sure that you would like to become the Team Maintainer? For awareness, this will inform other maintainers or members.\');',
+                    value='Preview')
+
+          if admin && showManagementFeatures
             ul.list-inline
               li: a.btn.btn-sm.btn-muted(href=teamUrl + 'maintainers/add') Add a team maintainer
 
@@ -236,7 +252,7 @@ block content
         if membersFirstPage  && display == 'default'
           h2
             = 'Members '
-            small: a(href=teamUrl + 'members/refresh', title='Refresh the team members list')
+            small: a(href=teamUrl + 'members/refresh', title='Refresh the team members list.  For performance reasons, this view may be cached.')
               i.glyphicon.glyphicon-refresh
 
           if membersFirstPage.length <= 0
@@ -249,12 +265,15 @@ block content
 
           ul.list-inline
             if membersFirstPage.length
-              li: a.btn.btn-sm.btn-muted(href=teamUrl + 'members/browse/', title='Only a subset of members are listed on this page. A full view is also available.')
+              li: a.btn.btn-sm.btn-muted(
+                href=teamUrl + 'members/browse/', 
+                onclick='return confirm(\'Are you sure that you want to browse on this site? The native GitHub experience will offer much better performance.\');'
+                title='Only a subset of members are listed on this page. A full view is also available.')
                 if teamDetails && teamDetails.members_count
                   = 'Browse all ' + teamDetails.members_count.toLocaleString() + ' members'
                 else
                   | Browse all team members
-            if admin
+            if admin && showManagementFeatures
               li: a.btn.btn-sm.btn-muted(href=teamUrl + 'members/add') Add a member
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -371,9 +390,9 @@ block content
           div.alert.alert-gray(role='alert')
             strong Have you considered GitHub.com?
             | &nbsp;
-            | You can directly manage this team and its maintainers on GitHub.com natively
+            | You can view this team and other information on GitHub.com natively
             | at: &nbsp
-            a(href='https://github.com/orgs/' + organization.name + '/teams/' + team.slug + '/members', target='_new')= 'https://github.com/orgs/' + organization.name + '/teams/' + team.slug + '/members'
+            a(href=team.nativeUrl + 'members', target='_new')= team.nativeUrl + 'members'
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         //- ADMINISTRATION
@@ -393,7 +412,7 @@ block content
             | &nbsp;
             | You can directly manage this team on GitHub.com natively
             | at:&nbsp;
-            a(href='https://github.com/orgs/' + organization.name + '/teams/' + team.slug + '/members', target='_new')= 'https://github.com/orgs/' + organization.name + '/teams/' + team.slug + '/members'
+            a(href=team.nativeUrl + 'members', target='_new')= team.nativeUrl + 'members'
           +authenticGitHubLink()
 
           ul.list-unstyled.list-vspace(style='margin-bottom:48px; margin-top:12px')
@@ -415,8 +434,9 @@ block content
         h4(style='margin-top:24px') Share
         p: small You can share these links with other users who need to work with this team.
         ul.list-unstyled.list-vspace
-          li: a.btn.btn-muted-more.btn-sm(href=teamUrl + 'join/', title='This URL can be shared for a linked user to join') Request to join this team
-          li: a.btn.btn-muted-more.btn-sm(href=teamUrl, title='This URL can be shared for anyone in the system to learn about what the team is and does') Get team information
+          li: a.btn.btn-muted-more.btn-sm(target='_new', href=teamUrl + 'join/', title='This URL can be shared for a linked user to join') Request to join this team
+          li: a.btn.btn-muted-more.btn-sm(target='_new', href=teamUrl, title='This URL can be shared for anyone in the system to learn about what the team is and does') Get team information
+          li: a.btn.btn-muted-more.btn-sm(target='_new', href=team.nativeUrl, title='This URL can be shared for anyone in the system to learn about what the team is and does') Native GitHub URL
 
         //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         //- CONTACT LINKS
@@ -428,13 +448,18 @@ block content
             if mailToMaintainers && mailToMaintainersCount
               li: a.btn.btn-muted-more.btn-sm(href=mailToMaintainers, title='Contact the maintainers') Contact #{mailToMaintainersCount} maintainers
             if mailToMembers && mailToMembersCount
-              li: a.btn.btn-muted-more.btn-sm(href=teamUrl, title='Contact the members') Contact #{mailToMembersCount} members
+              if mailToMembersCount === mailToMaintainersCount
+                // Same set of people
+              else
+                li: a.btn.btn-muted-more.btn-sm(href=teamUrl, title='Contact the members') Contact #{mailToMembersCount} members
 
     if membershipStatus && !isSystemTeam
       hr
       p
         form(method='post', action=teamUrl + 'leave')
-          button.btn.btn-default(type='submit') Leave #{team2.slug}
+          button.btn.btn-default(
+            onclick='return confirm(\'Are you sure that you want to leave this team?\');'
+            type='submit') Leave #{team2.slug}
 
     hr
     small

--- a/webhooks/tasks/team.ts
+++ b/webhooks/tasks/team.ts
@@ -29,10 +29,6 @@ export default class TeamWebhookProcessor implements WebhookProcessor {
   async run(operations: Operations, organization: Organization, data: any): Promise<boolean> {
     const queryCache = operations.providers.queryCache;
     const event = data.body;
-    const immediateRefreshOptions = {
-      backgroundRefresh: false,
-      maxAgeSeconds: 0.01,
-    };
     let refresh = false;
     let expectedAfterRefresh = false;
     const teamId = event.team.id;


### PR DESCRIPTION
This introduces a new opt-in (feature flag) capability to reduce the
amount of manual organization operations that are required for
common scenarios.

For a relatively small GitHub team size (configurable, default to
around 15 people), this allows people to self-service "upgrade"
themselves to be a team maintainer if the team does not have
many maintainers.

The # of maintainers that are supported by default for this feature
to light up is zero (0) or 1... since we recommend that every
team have at least 2 maintainers.

When a user upgrades themselves, this also contacts the other linked
maintainers (if there already is at least one), or the other members of the 
team (if there are no maintainers) so that there is awareness and
visibility of the change.