### PR TITLE
Improved link/join experience

### DIFF
--- a/middleware/errorHandler.ts
+++ b/middleware/errorHandler.ts
@@ -159,6 +159,7 @@ module.exports = function (err, req, res, next) {
     req.logout();
   }
   var safeMessage = redactRootPaths(err.message);
+  const defaultErrorTitle = err && err.skipOops ? 'FYI' : 'Oops';
   const view = {
     message: safeMessage,
     encodedMessage: querystring.escape(safeMessage),
@@ -167,11 +168,12 @@ module.exports = function (err, req, res, next) {
     detailed: err && err.detailed ? redactRootPaths(err.detailed) : undefined,
     encodedDetailed: err && err.detailed ? querystring.escape(redactRootPaths(err.detailed)) : undefined,
     errorFancyLink: err && err.fancyLink ? err.fancyLink : undefined,
+    errorFancySecondaryLink: err && err.fancySecondaryLink ? err.fancySecondaryLink : undefined,
     errorStatus: errorStatus,
     skipLog: err.skipLog,
     skipOops: err && err.skipOops ? err.skipOops : false,
     error: {},
-    title: err.title || (err.status === 404 ? 'Not Found' : 'Oops'),
+    title: err.title || (err.status === 404 ? 'Not Found' : defaultErrorTitle),
     primaryUser: primaryUserInstance,
     user: req.user,
     config: config && config.obfuscatedConfig ? config.obfuscatedConfig : null,

--- a/middleware/passport-routes.ts
+++ b/middleware/passport-routes.ts
@@ -155,7 +155,7 @@ module.exports = function configurePassport(app, passport, initialConfig) {
       res.render('message', {
         message: unlinked ? `Your ${config.brand.companyName} and GitHub accounts have been unlinked. You no longer have access to any ${config.brand.companyName} organizations, and you have been signed out of this portal.` : 'Goodbye',
         title: 'Goodbye',
-        buttonText: unlinked ? 'Re-link' : 'Sign In',
+        buttonText: unlinked ? 'Sign in to connect a new account' : 'Sign in',
         config: initialConfig.obfuscatedConfig,
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -787,6 +787,12 @@
       "integrity": "sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==",
       "dev": true
     },
+    "@types/validator": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
+      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@types/request": "2.48.4",
     "@types/request-promise-native": "1.0.17",
     "@types/uuid": "7.0.2",
+    "@types/validator": "13.0.0",
     "chai": "4.2.0",
     "mocha": "7.1.1",
     "typescript": "3.8.3"

--- a/routes/index-linked.ts
+++ b/routes/index-linked.ts
@@ -3,15 +3,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express from 'express';
 
-import { ReposAppRequest, IReposError } from '../transitional';
+import { ReposAppRequest } from '../transitional';
 import { IndividualContext } from '../user';
 import { storeOriginalUrlAsVariable } from '../utils';
 import { AuthorizeOnlyCorporateAdministrators } from '../middleware/business/corporateAdministrators';
 const router = express.Router();
+
+import unlinkRoute from './unlink';
 
 const orgsRoute = require('./orgs');
 const orgAdmin = require('./orgAdmin');
@@ -19,7 +19,6 @@ const peopleRoute = require('./people');
 const setupRoute = require('./administration');
 const reposRoute = require('./repos');
 const teamsRoute = require('./teams');
-const unlinkRoute = require('./unlink');
 const undoRoute = require('./undo');
 const contributionsRoute = require('./contributions');
 
@@ -63,4 +62,4 @@ router.use('/https?*github.com/:org/:repo', (req, res, next) => {
 
 router.use('/', orgsRoute);
 
-module.exports = router;
+export default router;

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -17,6 +17,7 @@ router.use('/myinfo', require('./diagnostics'));
 router.use('/explore', require('./explore'));
 router.use('/approvals', require('./approvals'));
 
-router.use(require('./index-authenticated'));
+import AuthenticatedRoute from './index-authenticated';
+router.use(AuthenticatedRoute);
 
 export default router;

--- a/routes/link-cleanup.ts
+++ b/routes/link-cleanup.ts
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-'use strict';
-
 import express = require('express');
 const router = express.Router();
 
@@ -183,4 +181,4 @@ router.use((req: ReposAppRequest, res, next) => {
 //   });
 // }
 
-module.exports = router;
+export default router;

--- a/routes/link.ts
+++ b/routes/link.ts
@@ -5,24 +5,19 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-'use strict';
-
 import express = require('express');
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
-
-import emailRender from '../lib/emailRender';
 
 import { ReposAppRequest, IProviders } from '../transitional';
 import { IndividualContext } from '../user';
 import { storeOriginalUrlAsReferrer, wrapError } from '../utils';
 import { ICorporateLink } from '../business/corporateLink';
-import { ILinkProvider } from '../lib/linkProviders';
 import { Operations, LinkOperationSource, SupportedLinkType } from '../business/operations';
 
-const isEmail = require('validator/lib/isEmail');
+import validator from 'validator';
 
-const unlinkRoute = require('./unlink');
+import unlinkRoute from './unlink';
 
 interface IRequestWithSession extends ReposAppRequest {
   session?: any;
@@ -197,7 +192,7 @@ async function linkUser(req, res, next) {
   const isServiceAccount = req.body.sa === '1';
   const serviceAccountMail = req.body.serviceAccountMail;
   const operations = req.app.settings.providers.operations as Operations;
-  if (isServiceAccount && !isEmail(serviceAccountMail)) {
+  if (isServiceAccount && !validator.isEmail(serviceAccountMail)) {
     return next(wrapError(null, 'Please enter a valid e-mail address for the Service Account maintainer.', true));
   }
   let newLinkObject: ICorporateLink = null;
@@ -248,4 +243,4 @@ router.get('/reconnect', function (req: ReposAppRequest, res, next) {
   });
 });
 
-module.exports = router;
+export default router;

--- a/routes/teamsPager.ts
+++ b/routes/teamsPager.ts
@@ -118,6 +118,7 @@ module.exports = asyncHandler(async function(req: ReposAppRequest, res: express.
       },
       yourTeamsMap,
       totalMemberships,
+      onboarding: req.query.onboarding,
       totalMaintainerships,
       errorAsWarning: null, // warning /* if an error occurs that is not fatal, we may want to display information about it */,
       onboardingOrJoining,

--- a/routes/unlink.ts
+++ b/routes/unlink.ts
@@ -5,8 +5,6 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-'use strict';
-
 import express = require('express');
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
@@ -65,7 +63,6 @@ router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
 router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
   const id = req.individualContext.getGitHubIdentity().id;
   const operations = req.app.settings.providers.operations as Operations;
-  // const account = operations.getAccount(id);
   const insights = req.insights;
   const terminationOptions = {
     reason: 'User used the unlink function on the web site',
@@ -96,4 +93,4 @@ router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
   }
 }));
 
-module.exports = router;
+export default router;

--- a/transitional.ts
+++ b/transitional.ts
@@ -212,6 +212,10 @@ export interface IReposError extends Error {
     link: string;
     title: string;
   };
+  fancySecondaryLink?: {
+    link: string;
+    title: string;
+  };
   innerError?: IReposError;
 }
 

--- a/views/error.pug
+++ b/views/error.pug
@@ -38,9 +38,12 @@ block content
         if detailed
           p.lead!= detailed
 
-        if errorFancyLink
-          p
-            a.btn.btn-primary(href=errorFancyLink.link)= errorFancyLink.title
+        if errorFancyLink || errorFancySecondaryLink
+          ul.list-inline
+            if errorFancyLink
+              li: a.btn.btn-primary(href=errorFancyLink.link)= errorFancyLink.title
+            if errorFancySecondaryLink
+              li: a.btn.btn-default(href=errorFancySecondaryLink.link)= errorFancySecondaryLink.title
 
         p
           if skipLog && !errorFancyLink

--- a/views/index.pug
+++ b/views/index.pug
@@ -15,10 +15,11 @@ block content
   - var overview = accountInfo ? accountInfo.overview : null
   div.container
     if onboarding === true
-      if user && user.azure
-        h1.huge Congratulations, #{user.azure.displayName || user.azure.username}
-      else
-        h1.huge Congratulations
+      .div.col-md-7
+        if user && user.azure
+          h1 Welcome, #{user.azure.displayName || user.azure.username}
+        else
+          h1 Welcome
     else
       //h1
         | Open Source Portal&nbsp;
@@ -60,7 +61,7 @@ block content
         h1
           a.a-unstyled(name='orgs') Your #{config.brand.companyName} GitHub organization memberships
       else
-        h3 You've successfully linked your #{config.brand.companyName} and GitHub accounts.
+        h4 You've successfully linked your #{config.brand.companyName} and GitHub accounts.
 
       - var currentPriority = ''
       - var oom = overview && overview.organizations ? overview.organizations.member : []
@@ -83,15 +84,13 @@ block content
           | Link your accounts&nbsp;
           i.glyphicon.glyphicon-ok
         h5.text-primary
-          | Join your first GitHub organization
+          strong Join your first GitHub organization
         h5
-          | Multifactor security checkup
+          | Profile review #[small: em optional]
         h5
-          | Profile review
+          | Publish your membership #[small: em optional]
         h5
-          | Publish your membership <em>(optional)</em>
-        h5
-          | Join a team <em>(optional)</em>
+          | Join a team #[small: em optional]
 
       //-if accountInfo.isSudoer
         h1 Organization Administration
@@ -199,11 +198,22 @@ block content
       if overview && overview.organizations && overview.organizations.available && overview.organizations.available.length
         hr
         h2 Available #{config.brand.companyName} GitHub organizations
-        p These are GitHub organizations that you have not yet joined.
+
+        if onboarding === true
+          .alert.alert-gray(style='color:#000')
+            strong Please join your first corporate GitHub org.
+            br
+            | Your link lets us know who you are, but there is more to be done.
+            br
+            br
+            | The company has many official GitHub orgs. You can choose which you would like to join from the list below.
+            br
+            br
+            | Most users join the official #{config.brand.companyName} org to participate in that great open source community.
+        else
+          p These are GitHub organizations that you are not a member of.
 
         .right
-          if onboarding === true
-            p Join these #{config.brand.companyName} organizations to see private repos and get elevated privileges.
 
           - var currentPriority = ''
           if groupedAvailableOrganizations
@@ -225,13 +235,19 @@ block content
                     a(href='/' + o.name + '/join' + onboardingPostfixUrl)
                       if groupType === 'secondary'
                         h6.text-muted
-                          strong= o.name + ' '
+                          strong(style='text-decoration: underline')= o.name
+                          = ' '
                           small: span.label.label-muted Join
+                        if true || onboarding === true
+                          p: small= o.nativeUrl
                         p.small.text-mute= o.description
                       else
                         h4
-                          = o.name + ' '
+                          span(style='text-decoration: underline')= o.name
+                          = ' '
                           small: span.label.label-primary Join
+                        if true || onboarding === true
+                          p: small= o.nativeUrl
                         p.small(style='color:#333')= o.description
 
     div.col-md-5

--- a/views/link.pug
+++ b/views/link.pug
@@ -70,17 +70,15 @@ block content
           | Sign in to your GitHub &amp; #{config.brand.companyName} accounts&nbsp;
           i.glyphicon.glyphicon-ok
         h5.text-primary
-          | Link your accounts
+          strong Link your accounts
         h5
           | Join your first GitHub organization
         h5
-          | Multifactor security checkup
-        h5
           | Profile review
         h5
-          | Publish your membership <em>(optional)</em>
+          | Publish your membership #[small: em optional]
         h5
-          | Join a team <em>(optional)</em>
+          | Join a team #[small: em optional]
 
       div.col-md-4.col-lg-4
         if user && user.github && user.github.id

--- a/views/org/pending.pug
+++ b/views/org/pending.pug
@@ -166,15 +166,13 @@ block content
               | Link your accounts&nbsp;
               i.glyphicon.glyphicon-ok
             h5.text-primary
-              | Join your first GitHub organization
-            h5
-              | Multifactor security checkup
+              strong Join your first GitHub organization
             h5
               | Profile review
             h5
-              | Publish your membership <em>(optional)</em>
+              | Publish your membership #[small: em optional]
             h5
-              | Join a team <em>(optional)</em>
+              | Join a team #[small: em optional]
 
         div.col-md-4.col-lg-4
           if orgAccount && orgAccount.organizationProfile

--- a/views/org/profileReview.pug
+++ b/views/org/profileReview.pug
@@ -16,10 +16,10 @@ block content
               p.lead Since you've just linked your #{config.brand.companyName} and GitHub accounts, it's a perfect time to think about how you show up in public on GitHub.
             p Your interactions in public open source repos (commenting on issues, creating and working with pull requests, contributing source) are all associated with your public GitHub profile. With #{config.brand.companyName}'s open source and social media policies in mind, consider the these questions:
             ul
-              li Are you using the name you use professionally?
-              li Have you identified #{config.brand.companyName} as your company?
+              li Are you using the name you would like to use in public?
+              li Have you identified #{config.brand.companyName} as your company in the bio, company field, or e-mail?
               li Have you included an e-mail address?
-              li Do you have a professional, smart profile avatar?
+              li Do you have a profile avatar that is work-appropriate and professional?
             p &nbsp;
             p
               a.btn.btn-primary.btn-lg(href=organization.baseUrl + (onboarding ? 'membership?onboarding=' + onboarding : 'membership')) Continue
@@ -40,15 +40,12 @@ block content
               h5
                 | Join your first GitHub organization&nbsp;
                 i.glyphicon.glyphicon-ok
-              h5
-                | Multifactor security checkup&nbsp;
-                i.glyphicon.glyphicon-ok
               h5.text-primary
-                | Profile review
+                strong Profile review
               h5
-                | Publish your membership <em>(optional)</em>
+                | Publish your membership #[small: em optional]
               h5
-                | Join a team <em>(optional)</em>
+                | Join a team #[small: em optional]
 
           div.col-lg-4.col-md-4.col-sm-4
             div.row

--- a/views/org/publicMembershipStatus.pug
+++ b/views/org/publicMembershipStatus.pug
@@ -72,6 +72,6 @@ block content
         | Profile review&nbsp;
         i.glyphicon.glyphicon-ok
       h5.text-primary
-        | Publish your membership <em>(optional)</em>
+        strong Publish your membership
       h5
-        | Join a team <em>(optional)</em>
+        | Join a team #[small: em optional]

--- a/views/teams/index.pug
+++ b/views/teams/index.pug
@@ -19,6 +19,22 @@ block content
       h1 GitHub Teams
       p.lead Across all officially managed #{config.brand.companyName} organizations
 
+    if onboarding
+      .alert.alert-gray
+        strong You're all set for use GitHub for open source now.
+        br
+        | You may need to join a GitHub Team at some point. Teams provide access to GitHub repos with specific permissions: for example, a team with admin permission to a repo will have the ability to manage the repo's settings, make it public or private, etc.
+        br
+        br
+        | For the majority of the work you do on GitHub, you can submit a pull request from your individual fork of a project without needing any special permission to contribute back.
+        br
+        br
+        | You can #[a(href='https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams', target='_new') learn more about GitHub Teams on the GitHub Help site].
+        if organization
+          br
+          br
+          a.btn.btn-default.btn-sm(href=organization.baseUrl) Go to the main #{organization.name} page
+
     .row
       .col-md-8
         form.form-horizontal#entitySearch(style='margin-top:24px')


### PR DESCRIPTION
To help address user confusion.

- Allows people to unlink themselves in the "security mismatch" scenario which used to take bothering us for manual ops
- Cleans up the first-time user experience to clearly remind them to join a GitHub org (i.e. "you aren't done yet!")
- Cleans up the first-time experience when you land on the Teams view with instructions pointing you at the GitHub Help page for GitHub Teams, and then telling you you likely do not need to do anything. Includes a button to go to the org main page as well.