### PR TITLE
The postgres compress object returned gibberish

### DIFF
--- a/lib/caching/redis.ts
+++ b/lib/caching/redis.ts
@@ -30,7 +30,7 @@ export interface IRedisHelperOptions {
 export default class RedisHelper implements ICacheHelper {
   private _redis: redis.RedisClient;
   private _prefix: string;
-  
+
   constructor(options: IRedisHelperOptions) {
     if (!options.redisClient) {
       throw new Error('options.redisClient required by RedisHelper');
@@ -38,7 +38,7 @@ export default class RedisHelper implements ICacheHelper {
     this._prefix = options.prefix ? options.prefix + '.' : '';
     this._redis = options.redisClient;
   }
-  
+
   private key(key: string) {
     return this._prefix + key;
   }
@@ -123,7 +123,7 @@ export default class RedisHelper implements ICacheHelper {
   }
 
   async getObjectCompressed(key: string): Promise<any> {
-    const value = await this.getObject(key);
+    const value = await this.getCompressed(key);
     return JSON.parse(value);
   }
 

--- a/lib/github/core.ts
+++ b/lib/github/core.ts
@@ -172,7 +172,7 @@ export abstract class IntelligentEngine {
 
   protected async tryGetCachedResult(apiContext): Promise<any> {
     const key = this.redisKeyBodyVersion(apiContext);
-    const response = await apiContext.libraryContext.redis.getObjectCompressed(this.redisKeyBodyVersion(apiContext));
+    const response = await apiContext.libraryContext.redis.getObjectCompressed(key);
     this.recordRedisCost(apiContext, 'get', response);
     await this.storeLocalResult(apiContext, response);
     return response;


### PR DESCRIPTION
Wrong method called getObject instead of getCompressed.

When cache is stored as compressed object, it is gzipped however the getObject returns gzipped object before extracting, the JSON.Parse fails.