### PR TITLE
dtrace provider + node gyp needs make, g++, python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG NPM_TOKEN
 # Make Git available for NPM and rsync in the build image
 RUN apk add --update git && rm -rf /var/cache/apk/*
 
+# Add node-gyp dependencies
+RUN apk add python make gcc g++
+
 WORKDIR /build
 COPY package.json .
 COPY package-lock.json .


### PR DESCRIPTION
During a docker build, node tries to install the dtrace-provider which fails due to missing dependencies:

https://github.com/microsoft/opensource-portal/pull/156/checks?check_run_id=921910588#step:4:45