### PR TITLE
Fix missing corporate views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ sync-*.js
 # Local development environment scripts
 app.yaml
 env.json
+.env

--- a/middleware/corporateViews.ts
+++ b/middleware/corporateViews.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { promises as fs } from 'fs';
+import { constants as fsConstants, promises as fs } from 'fs';
 import path from 'path';
 
 import { IProviders, stripDistFolderName } from '../transitional';
@@ -29,6 +29,11 @@ export default async function initializeCorporateViews(providers: IProviders, di
   const { config } = providers.config;
   const appDirectory = config && config.typescript && config.typescript.appDirectory ? config.typescript.appDirectory : stripDistFolderName(dirname);
   const corporateViewsRoot = path.resolve(path.join(appDirectory, 'views', 'corporate'));
+  try {
+    await fs.access(corporateViewsRoot, fsConstants.R_OK);
+  } catch (err) {
+    return null;
+  }
   return await recurseDirectory(corporateViewsRoot);
 }
 


### PR DESCRIPTION
This is to fix an error if you have not created a `views/corporate/` folder:

```
Error: ENOENT: no such file or directory, scandir '/working/directory/opensource-portal/views/corporate'
```