### PR TITLE
Fix inconsistent indentation and remove trailing whitespace

### DIFF
--- a/views/teams/index.pug
+++ b/views/teams/index.pug
@@ -19,7 +19,7 @@ block content
       h1 GitHub Teams
       p.lead Across all officially managed #{config.brand.companyName} organizations
 
-if onboarding
+    if onboarding
       .alert.alert-gray
         strong You're all set for use GitHub for open source now.
         br
@@ -120,7 +120,7 @@ if onboarding
                 if next_possible
                   a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
-                else  
+                else
                   span(aria-hidden="true") Next &rarr;
 
           .container
@@ -156,7 +156,7 @@ if onboarding
                 if previous_possible
                   a(href='?page_number=' + (search.page-1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
-                else  
+                else
                   span(aria-hidden="true") &larr; Previous
               li
                 h4(style="display:inline")
@@ -165,7 +165,7 @@ if onboarding
                 if next_possible
                   a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
-                else  
+                else
                   span(aria-hidden="true") Next &rarr;
 
       .col-md-3.col-md-offset-1


### PR DESCRIPTION
This PR resolves an issue where the teams view throws an error due to inconsistent indention with indenting the `if onboarding` with 4 spaces. 
```
portal_1        | GET /ospo-testing-org/teams?joining=ospo-testing-org 302 1.602 ms - 90 plain dbdbc016-0e25-4cf7-80f9-8e4d6260aca6
portal_1        | Error: /usr/src/repos/views/teams/index.pug:38:1
portal_1        |     36|           a.btn.btn-default.btn-sm(href=organization.baseUrl) Go to the main #{organization.name} page
portal_1        |     37|
portal_1        |   > 38|     .row
portal_1        | --------^
portal_1        |     39|       .col-md-8
portal_1        |     40|         form.form-horizontal#entitySearch(style='margin-top:24px')
portal_1        |     41|           .form-group
portal_1        |
portal_1        | Inconsistent indentation. Expecting either 0 or 6 spaces/tabs.
```

Additionally I removed the trailing whitespace from a few lines to tidy the file up a bit.