### PR TITLE
use config.graph.require to disable graph provider check and corporateValidation

### DIFF
--- a/business/operations.ts
+++ b/business/operations.ts
@@ -638,7 +638,7 @@ export class Operations {
     if (!linkProvider) {
       throw CreateError.ServerError('linkProvider required');
     }
-    if (!graphProvider) {
+    if (this.config.graph?.require === true && !graphProvider) {
       throw CreateError.ServerError('Graph provider required');
     }
     if (!options.link) {
@@ -675,7 +675,7 @@ export class Operations {
     }
 
     let mailAddress: string = null;
-    if (!options.skipCorporateValidation) {
+    if (this.config.graph?.require === true && !options.skipCorporateValidation) {
       try {
         const corporateInfo = await this.validateCorporateAccountCanLink(link.corporateId);
         const corporateAccount = corporateInfo.graphEntry;


### PR DESCRIPTION
This PR makes the usage of the GraphProvider optional and uses the `config.graph.require` variable to determine if corporateValidation should be used and if an error should be thrown if a graph provider is not configured. 

Similiar to how already the check in the initialize phase is done: https://github.com/microsoft/opensource-portal/blob/ead2c878142f9e30ca077df4d8765db43b2d4cd5/middleware/initialize.ts#L412-L414