### PR TITLE
make the links table the default table for storing links

### DIFF
--- a/config/github.links.postgres.json
+++ b/config/github.links.postgres.json
@@ -1,4 +1,4 @@
 {
-  "tableName": "env://REPOS_POSTGRES_LINKS_TABLE_NAME",
+  "tableName": "env://REPOS_POSTGRES_LINKS_TABLE_NAME?default=links",
   "githubThirdPartyName": "env://REPOS_POSTGRES_LINKS_GITHUB_THIRD_PARTY_NAME?default=github"
 }


### PR DESCRIPTION
This PR sets a default for the `config.github.links.postgres.tableName` to the reasonable value `links`. This is the same tablename, which is created via `pg.sql` and therefore makes it easier to setup without needing to fiddle too much with the settings. 

https://github.com/microsoft/opensource-portal/blob/a17d48e8efd1a4b299363acb3049eee1f5983487/pg.sql#L148-L163 