### PR TITLE
make redis auth optional and disable protected mode for docker redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
 
   portal-cache:
     image: redis
+    command: redis-server --protected-mode no
     networks:
       - portal
 

--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -470,9 +470,9 @@ function connectRedis(config: any, redisConfig: any, purpose: string): Promise<r
   const nodeEnvironment = config && config.node ? config.node.environment : null;
   let redisClient: redis.RedisClient = null;
   const redisOptions: RedisOptions = {
-    auth_pass: redisConfig.key,
     detect_buffers: true,
   };
+  if (config.redis.key) redisOptions.auth_pass = config.redis.key;
   if (redisConfig.tls) {
     redisOptions.tls = {
       servername: redisConfig.tls,
@@ -499,8 +499,10 @@ function connectRedis(config: any, redisConfig: any, purpose: string): Promise<r
       }
     });
     // NOTE: a timeout would hang the process here
-    redisClient.auth(config.redis.key);
-    debug(`authenticated to Redis for ${purpose}`);
+    if (config.redis.key) {
+      redisClient.auth(config.redis.key);
+      debug(`authenticated to Redis for ${purpose}`);
+    }
   });
 }
 

--- a/transitional.ts
+++ b/transitional.ts
@@ -230,7 +230,7 @@ export interface IApplicationProfile {
 }
 
 export interface RedisOptions {
-  auth_pass: string;
+  auth_pass?: string;
   detect_buffers: boolean;
   tls?: {
     servername: string;


### PR DESCRIPTION
This PR implements that when `config.redis.key` is not set authentication to the redis cache isn't tried (and fails).

Additionally it adds to the `docker-compose.yml` that the redis should start in unprotected mode to allow unauthenticated connections. 

Alternatively we could as well set a default key in both the redis configuration and the docker compose via `redis-server --requirepass yourpassword`