### PR TITLE
make use and release link configurable

### DIFF
--- a/config/microsoftOpenSource.json
+++ b/config/microsoftOpenSource.json
@@ -1,6 +1,8 @@
 {
   "witness": "env://OPENSOURCE_WITNESS_LINK",
   "explore": "env://OPENSOURCE_EXPLORE_LINK",
+  "use": "env://OPENSOURCE_USE_LINK",
+  "release": "env://OPENSOURCE_RELEASE_LINK",
   "legacyTool": "env://OPENSOURCE_LEGACY_TOOL_LINK",
   "docs": "env://OPENSOURCE_DOCS_LINK",
   "repos": "env://OPENSOURCE_REPOS_LINK",

--- a/views/nav2.pug
+++ b/views/nav2.pug
@@ -72,9 +72,11 @@ div.navbar.navbar-default(style=reposContext ? 'margin-bottom:0' : undefined)
         if config.microsoftOpenSource.docs
           li: a(href=config.microsoftOpenSource.docs) Docs
         li(class={ active: site === 'use' })
-          a(href=config.microsoftOpenSource.explore + 'use') Use
+          // check if a dedicated "use" link is configured and if that is the case use that
+          a(href=config.microsoftOpenSource.use || config.microsoftOpenSource.explore + 'use') Use
         li(class={ active: (reposContext && reposContext.releaseTab) || site === 'release' })
-          a(href=config.microsoftOpenSource.explore + 'release') Release
+          // check if a dedicated "use" link is configured and if that is the case use that
+          a(href=config.microsoftOpenSource.release || config.microsoftOpenSource.explore + 'release') Release
         li(class={ active: (reposContext && !reposContext.releaseTab) && site === 'github' })
           a(
             style=((reposContext && !reposContext.releaseTab) && site === 'github' && ossLink && reposContext) ? 'color:#fff;background-color:#0072C6' : undefined,

--- a/views/nav2.pug
+++ b/views/nav2.pug
@@ -72,10 +72,10 @@ div.navbar.navbar-default(style=reposContext ? 'margin-bottom:0' : undefined)
         if config.microsoftOpenSource.docs
           li: a(href=config.microsoftOpenSource.docs) Docs
         li(class={ active: site === 'use' })
-          // check if a dedicated "use" link is configured and if that is the case use that
+          // check if a dedicated "use" link is configured and if that is the case use that, otherwise fallback to the use subpage on the explore link
           a(href=config.microsoftOpenSource.use || config.microsoftOpenSource.explore + 'use') Use
         li(class={ active: (reposContext && reposContext.releaseTab) || site === 'release' })
-          // check if a dedicated "use" link is configured and if that is the case use that
+          // check if a dedicated "release" link is configured and if that is the case use that, otherwise fallback to the release subpage on the explore link
           a(href=config.microsoftOpenSource.release || config.microsoftOpenSource.explore + 'release') Release
         li(class={ active: (reposContext && !reposContext.releaseTab) && site === 'github' })
           a(


### PR DESCRIPTION
This PR allows that the link behind "Use" and "Release" on the header of the portal can be configured with a custom link. 

This is especially helpful if resources for use/release of open source is not located at `config.microsoftOpenSource.explore + 'release'`, but in other places (e.g. dedicated wiki pages). 

If the configuration is not set it will default to the current behavior. 
