### PR TITLE
Remove explicit color from companyPortalName

### DIFF
--- a/views/nav2.pug
+++ b/views/nav2.pug
@@ -64,7 +64,7 @@ div.navbar.navbar-default(style=reposContext ? 'margin-bottom:0' : undefined)
         span.icon-bar
         span.icon-bar
       if config && config.urls && config.urls && config.urls.explore
-        a.navbar-brand(href=config.urls.explore, style='font-size:16px;color:#333')
+        a.navbar-brand(href=config.urls.explore, style='font-size:16px')
           = config.brand && config.brand.companyPortalName ? config.brand.companyPortalName : 'GitHub Management Portal'
     // Collect the nav links, forms, and other content for toggling
     div.collapse.navbar-collapse#bs-example-navbar-collapse-1


### PR DESCRIPTION
This PR removes the explicit color from the Portal name as with the default asset pack it would be the same as the background of the header: 
![image](https://user-images.githubusercontent.com/16856448/110824831-b39ac480-8293-11eb-9ede-14398b985f2e.png)

After removing the the explicit color (aka what this PR does): 
![image](https://user-images.githubusercontent.com/16856448/110824887-c1504a00-8293-11eb-9e02-cf9ee79283bc.png)

---

⚠️ Depending on what color scheme the Microsoft internal version uses, this may cause problems.

For this the color could be added in the css as important (as otherwise the bootstrap default of `#fff` will be used) file of the microsoft asset pack like this:
```css
.navbar-brand {
  color: #333 !important;
}
``` 

