### PR TITLE
fix previous/next links to be correctly enabled

### DIFF
--- a/views/people/index.pug
+++ b/views/people/index.pug
@@ -154,23 +154,12 @@ block content
           nav(style='margin-bottom:48px')
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
+                a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
-                else
-                  span(aria-hidden="true") &larr; Previous
-                  a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") &larr; Previous
               li
-                if search.totalItems == 1
-                  | One member
-                else
-                  | #{search.pageFirstItem.toLocaleString()} - #{search.pageLastItem.toLocaleString()} of #{search.totalItems.toLocaleString()} #{itemType}
+                | #{search.pageFirstItem.toLocaleString()} - #{search.pageLastItem.toLocaleString()} of #{search.totalItems.toLocaleString()} #{itemType}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
           .row.vertical-pad-bottom
@@ -273,7 +262,7 @@ block content
                     ul.list-inline(style='margin-top:7.5%')
                       li
                         .label.label-danger Not linked
-                
+
               .col-sm-2
                 if !organization && person.orgs
                   - var localOrgList = Object.getOwnPropertyNames(person.orgs)
@@ -294,22 +283,16 @@ block content
           nav
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") &larr; Previous
-                else
+                a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 h4(style="display:inline")
                   | Page #{search.page} of #{search.totalPages}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
         hr
         p.
-          This view is cached and eventually consistent within a few hours. 
+          This view is cached and eventually consistent within a few hours.
           The presence of people in this list does not imply that they are an employee.

--- a/views/repos/index.pug
+++ b/views/repos/index.pug
@@ -209,18 +209,12 @@ block content
           nav(style='margin-bottom:48px')
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") &larr; Previous
-                else
+                a(href='?page_number=' + (search.page-1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 | #{search.pageFirstRepo.toLocaleString()} - #{search.pageLastRepo.toLocaleString()} of #{search.totalRepos.toLocaleString()}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
           each repo in search.repos
@@ -299,19 +293,13 @@ block content
           nav
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") &larr; Previous
-                else
+                a(href='?page_number=' + (search.page-1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 h4(style="display:inline")
                   | Page #{search.page} of #{search.totalPages}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                    span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (specificTeamId ? '&teamRepos=' + specificTeamId : '') + (tag ? '&tag=' + tag : '') + (query.tt ? '&tt=' + query.tt : '') + (search.sort ? '&sort=' + search.sort : '') + (query.language ? '&language=' + search.observedLanguagesEncoded.get(query.language) : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
       .col-md-3.col-md-offset-1

--- a/views/teams/index.pug
+++ b/views/teams/index.pug
@@ -109,18 +109,12 @@ block content
           nav(style='margin-bottom:48px')
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") &larr; Previous
-                else
+                a(href='?page_number=' + (search.page-1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 | #{search.pageFirstTeam.toLocaleString()} - #{search.pageLastTeam.toLocaleString()} of #{search.totalTeams.toLocaleString()}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
           .container
@@ -153,19 +147,13 @@ block content
           nav
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                if previous_possible
-                  a(href='?page_number=' + (search.page-1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") &larr; Previous
-                else
+                a(href='?page_number=' + (search.page-1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 h4(style="display:inline")
                   | Page #{search.page} of #{search.totalPages}
               li.next(class=(next_possible ? '' : 'invisible'))
-                if next_possible
-                  a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
-                  span(aria-hidden="true") Next &rarr;
-                else
+                a(href='?page_number=' + (search.page+1) + (query.set ? '&set=' + query.set : '') + (query.phrase ? '&q=' + query.phrase : ''))
                   span(aria-hidden="true") Next &rarr;
 
       .col-md-3.col-md-offset-1


### PR DESCRIPTION
This PR fixes a small visible bug in the UI, where the "next ->" & "<- previous" link on the repo, people and team pager are not correctly intended and thus the link is not behind the text.

Additionally I remove the if statement and just relay on hiding the element with the CSS class and that works great and reduces the complexity a bit.

Lastly it as well removes the special logic to switch between displaying `One member` if only a single member is returned and just use the default template (`1 - 1 of 1 members`)

<details>
<summary>Visualized rendered output before</summary>

![image](https://user-images.githubusercontent.com/16856448/111339430-0b607380-8678-11eb-8e11-d51fe01fd6d7.png)
```html
<ul class="pager">
   <li class="previous">
     <a href="?page_number=2&amp;sort=Alphabet"></a>
     <span aria-hidden="true">← Previous</span> 
   </li>
   <li>67 - 99 of 36,842 members</li>
   <li class="next">
     <a href="?page_number=4&amp;sort=Alphabet"></a>
     <span aria-hidden="true">Next →</span>
   </li>
</ul>
```
</details>

<details>
<summary>Visualized rendered output after</summary>

![image](https://user-images.githubusercontent.com/16856448/111338196-06e78b00-8677-11eb-8145-005c93b93ff0.png)
```html
<ul class="pager">
  <li class="previous">
    <a href="?page_number=0&amp;sort=Alphabet">
      <span aria-hidden="true">← Previous</span>
    </a>
  </li>
  <li>67 - 99 of 36,842 members</li>
  <li class="next">
    <a href="?page_number=2&amp;sort=Alphabet">
      <span aria-hidden="true">Next →</span>
    </a>
  </li>
</ul>
```

</details>

