### PR TITLE
Organization sudo security group support

### DIFF
--- a/config/features.json
+++ b/config/features.json
@@ -4,5 +4,6 @@
   "allowUnauthorizedForkLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_FORK_LOCKDOWN_SYSTEM?trueIf=1",
   "allowUnauthorizedTransferLockdownSystem": "env://FEATURE_FLAG_ALLOW_UNAUTHORIZED_TRANSFER_LOCKDOWN_SYSTEM?trueIf=1",
   "allowUndoSystem": "env://FEATURE_FLAG_ALLOW_UNDO_SYSTEM?trueIf=1",
+  "allowOrganizationSudo": "env://FEATURE_FLAG_ALLOW_ORG_SUDO?trueIf=1&default=1",
   "allowFossFundElections": "env://FEATURE_FLAG_FOSS_FUND_ELECTIONS?trueIf=1"
 }

--- a/config/github.debug.json
+++ b/config/github.debug.json
@@ -1,5 +1,4 @@
 {
   "portalSudoOff": "env://DEBUG_GITHUB_PORTAL_SUDO_OFF?trueIf=1",
-  "orgSudoOff": "env://DEBUG_GITHUB_ORG_SUDO_OFF?trueIf=1",
   "portalSudoForce": "env://DEBUG_GITHUB_PORTAL_SUDO_FORCE?trueIf=1"
 }

--- a/config/sudo.json
+++ b/config/sudo.json
@@ -1,0 +1,7 @@
+{
+  "organization": {
+    "off": "env://DEBUG_GITHUB_ORG_SUDO_OFF?trueIf=1",
+    "defaultProviderName": "env://SUDO_ORGANIZATION_PROVIDER_DEFAULT_NAME?default=githubteams",
+    "allowUniqueProvidersByOrganization": "env://SUDO_ORGANIZATION_PROVIDER_ALLOW_UNIQUE?trueIf=1"
+  }
+}

--- a/features/README.md
+++ b/features/README.md
@@ -1,0 +1,16 @@
+# Features
+
+There was an early thinking that "features" would provide feature-flag, independently-implemented 
+capabilities or sub-applications.
+
+I don't think the design has really panned out. Open to feedback here.
+
+## Organization sudo
+
+> This feature is enabled by default but only lights up when orgs are configured for it.
+
+Allows a set of users to have elevated privileges when using the portal. Helpful for 
+helping support a large organization with a set of trusted users configured at the organization 
+level to reduce persistent owner permissions.
+
+[Review the sudo feature docs](sudo/sudo.md)

--- a/features/index.ts
+++ b/features/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+export * from './sudo';

--- a/features/newRepositoryLockdown.ts
+++ b/features/newRepositoryLockdown.ts
@@ -14,7 +14,7 @@ import { RepositoryMetadataEntity, GitHubRepositoryVisibility, RepositoryLockdow
 import { IndividualContext } from '../user';
 import { daysInMilliseconds } from '../utils';
 
-import moment = require('moment');
+import moment from 'moment';
 
 const botBracket = '[bot]';
 

--- a/features/sudo/index.ts
+++ b/features/sudo/index.ts
@@ -1,0 +1,76 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import type { ICorporateLink, Organization } from '../../business';
+import getCompanySpecificDeployment from '../../middleware/companySpecificDeployment';
+import { IProviders } from '../../transitional';
+
+export interface IOrganizationSudo {
+  isSudoer(githubLogin: string, link?: ICorporateLink): Promise<boolean>;
+}
+
+export abstract class OrganizationSudo implements IOrganizationSudo {
+  constructor(protected providers: IProviders, protected organization: Organization) {}
+  abstract isSudoer(githubLogin: string, link?: ICorporateLink): Promise<boolean>;
+
+  protected isSudoEnvironmentOff() {
+    // Optional helper for debugging, if the provider chooses to respect the deployment environment
+    const config = this.providers.config;
+    if (config?.sudo?.organization?.off) {
+      console.warn('DEBUG WARNING: Organization sudo support is turned off in the current environment');
+      return true;
+    }
+    return false;
+  }
+}
+
+export { OrganizationFeatureSecurityGroupProperty } from './securityGroup';
+
+import { OrganizationSudoNoop } from './noop';
+import { OrganizationSudoSecurityGroup } from './securityGroup';
+import { OrganizationSudoGitHubTeams } from './teams';
+
+export function createOrganizationSudoInstance(providers: IProviders, organization: Organization): IOrganizationSudo {
+  const override = getCompanySpecificDeployment();
+  let instance = override?.features?.organizationSudo?.tryCreateInstance(providers, organization);
+  if (instance) {
+    return instance;
+  }
+
+  const config = providers.config;
+  const defaultProviderName = config?.sudo?.organization?.defaultProviderName;
+  
+  let providerName = defaultProviderName;
+
+  const allowUniqueProvidersByOrganization = config?.sudo?.organization?.allowUniqueProvidersByOrganization;
+  if (allowUniqueProvidersByOrganization) {
+    const name = getProviderNameForOrganization(organization);
+    if (name) {
+      providerName = name;
+    }
+  }
+
+  instance = createProviderInstance(providerName, providers, organization);
+  return instance;
+}
+
+function getProviderNameForOrganization(organization: Organization) {
+  if (OrganizationSudoSecurityGroup.forOrganization(organization)) {
+    return OrganizationSudoSecurityGroup.providerName;
+  }
+}
+
+function createProviderInstance(providerName: string, providers: IProviders, organization: Organization) {
+  switch (providerName) {
+    case 'noop':
+      return new OrganizationSudoNoop(providers, organization);
+    case 'githubteams':
+      return new OrganizationSudoGitHubTeams(providers, organization);
+    case OrganizationSudoSecurityGroup.providerName:
+      return new OrganizationSudoSecurityGroup(providers, organization);
+    default:
+      throw new Error(`OrganizationSudo: unsupported or unconfigured provider name=${providerName}`);
+  }
+}

--- a/features/sudo/noop.ts
+++ b/features/sudo/noop.ts
@@ -1,0 +1,18 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { OrganizationSudo } from '.';
+import { ICorporateLink, Organization } from '../../business';
+import { IProviders } from '../../transitional';
+
+export class OrganizationSudoNoop extends OrganizationSudo {
+  constructor(protected providers: IProviders, protected organization: Organization) {
+    super(providers, organization);
+  }
+
+  isSudoer(githubLogin: string, link?: ICorporateLink): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+}

--- a/features/sudo/securityGroup.ts
+++ b/features/sudo/securityGroup.ts
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { OrganizationSudo } from '.';
+import { ICorporateLink, Organization } from '../../business';
+import { ErrorHelper, IProviders } from '../../transitional';
+
+export const OrganizationFeatureSecurityGroupProperty = 'orgsudosecuritygroup';
+
+export class OrganizationSudoSecurityGroup extends OrganizationSudo {
+  static providerName = 'securitygroup';
+
+  static forOrganization(organization: Organization) {
+    if (!organization.hasDynamicSettings) {
+      return null;
+    }
+    const settings = organization.getDynamicSettings();
+  
+    // Security group flips on security groups
+    const val = settings.getProperty(OrganizationFeatureSecurityGroupProperty) as string;
+    if (val) {
+      return OrganizationSudoSecurityGroup.providerName;
+    }
+  }
+
+  constructor(providers: IProviders, organization: Organization) {
+    super(providers, organization);
+  }
+
+  async isSudoer(githubLogin: string, link?: ICorporateLink): Promise<boolean> {
+    const { insights } = this.providers;
+    if (this.isSudoEnvironmentOff()) {
+      return false;
+    }
+    if (!link || !link.corporateId) {
+      return false;
+    }
+    const corporateId = link.corporateId;
+    const organization = this.organization;
+    const settings = organization.getDynamicSettings();
+    if (!settings) {
+      return false;
+    }
+    const securityGroupId = settings.getProperty(OrganizationFeatureSecurityGroupProperty) as string;
+    if (!securityGroupId) {
+      return false;
+    }
+    const { graphProvider } = this.providers;
+    if (!graphProvider) {
+      throw new Error('No graph provider configured');
+    }
+    try {
+      if (await graphProvider.isUserInGroup(corporateId, securityGroupId)) {
+        insights?.trackEvent({
+          name: 'OrganizationSudoAuthorized',
+          properties: {
+            corporateId,
+            securityGroupId,
+            organizationName: organization.name,
+          },
+        });
+        return true;
+      }
+    } catch (error) {
+      if (ErrorHelper.IsNotFound(error)) { // security groups do get deleted and should not bring down any system in that case
+        return false;
+      }
+      console.warn(error);
+      insights?.trackException({
+        exception: error,
+        properties: {
+          eventName: 'OrganizationSudoSecurityGroupError',
+          className: 'OrganizationSudoSecurityGroup',
+          callName: 'isUserInGroup',
+          organizationName: organization.name,
+        },
+      });
+      return false;
+    }
+    return false;
+  }
+}

--- a/features/sudo/sudo.md
+++ b/features/sudo/sudo.md
@@ -1,0 +1,40 @@
+
+# sudo / organization sudo
+
+Organization-level sudo allows users that are not technically organization owners on 
+GitHub to perform administrative actions that the portal provides, such as managing repos, 
+or taking action on behalf of some users.
+
+When using repository-level just-in-time (JIT), sudo also allows org sudo users to 
+JIT to help manage repositories.
+
+## Feature flag: FEATURE_FLAG_ALLOW_ORG_SUDO
+
+> This feature is **ON** by default
+
+Historically, this project enabled organization sudoers by default. The configuration 
+default for the feature flag `allowOrganizationSudo` from environment `FEATURE_FLAG_ALLOW_ORG_SUDO` 
+reflects this default.
+
+## Configuration options
+
+The default provider uses GitHub Teams for authorization: a specific GitHub team ID is 
+configured for an organization. Membership in that GitHub Team for the user at the time
+of the request is used to grant org-level sudo permission.
+
+For those wanting to use security groups, a security group provider available. This 
+decouples the operations from the GitHub user and instead is based off of the privileges 
+of the linked user's corporate ID.
+
+An abstract base class is available but not required to conform to the interface.
+
+## Company-specific support
+
+Overrides are available to allow the company-specific system to provide the 
+org sudo instance for an organization, if you wish to implement a different 
+approach, or use a different company-internal system for these decisions.
+
+## Debug flags
+
+There is an environmental off-switch enabled that can turn off sudo, allowing for testing 
+as a regular user in local environments. That env variable name is `DEBUG_GITHUB_ORG_SUDO_OFF`.

--- a/features/sudo/teams.ts
+++ b/features/sudo/teams.ts
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+import { OrganizationSudo } from '.';
+import { GitHubTeamRole, ICorporateLink, ITeamMembershipRoleState, Organization } from '../../business';
+import { ErrorHelper, IProviders } from '../../transitional';
+
+export class OrganizationSudoGitHubTeams extends OrganizationSudo {
+  constructor(providers: IProviders, organization: Organization) {
+    super(providers, organization);
+  }
+
+  async isSudoer(githubLogin: string, link?: ICorporateLink): Promise<boolean> {
+    if (this.isSudoEnvironmentOff()) {
+      return false;
+    }
+
+    const organization = this.organization;
+    const sudoerTeam = organization.sudoersTeam;
+    if (!sudoerTeam) {
+      return false;
+    }
+
+    let membership: GitHubTeamRole = null;
+    try {
+      const response = await sudoerTeam.getMembershipEfficiently(githubLogin);
+      if (response && (response as ITeamMembershipRoleState).role) {
+        membership = (response as ITeamMembershipRoleState).role;
+      }
+    } catch (getMembershipError) {
+      if (ErrorHelper.IsNotFound(getMembershipError)) {
+        return false;
+      }
+      throw getMembershipError;
+    }
+    const isKnownMembership = membership === GitHubTeamRole.Member || membership === GitHubTeamRole.Maintainer;
+    if (membership && isKnownMembership) {
+      return isKnownMembership;
+    } else if (membership) {
+      throw new Error(`Cannot determine sudo status for ${githubLogin}, unrecognized membership type: ${membership}`);
+    } else {
+      return false;
+    }
+  }
+}

--- a/interfaces/companySpecificLightup.ts
+++ b/interfaces/companySpecificLightup.ts
@@ -4,14 +4,26 @@
 //
 
 import { Router } from 'express';
+import { Organization } from '../business';
 import { Repository } from '../business/repository';
+import { OrganizationSudo } from '../features/sudo';
 import { IContextualRepositoryPermissions } from '../middleware/github/repoPermissions';
 import { IDictionary, IProviders } from '../transitional';
 import { IndividualContext } from '../user';
 
+// We're great at long variable names at Microsoft!
+
 export interface IAttachCompanySpecificRoutes {
   connectAuthenticatedRoutes: (router: Router, reactRoute: any) => void;
   connectCorporateApiRoutes: (router: Router) => void;
+}
+
+export interface ICompanySpecificFeatureOrganizationSudo {
+  tryCreateInstance: (providers: IProviders, organization: Organization) => OrganizationSudo;
+}
+
+export interface ICompanySpecificFeatures {
+  organizationSudo?: ICompanySpecificFeatureOrganizationSudo;
 }
 
 export interface ICompanySpecificStartupProperties {
@@ -19,6 +31,7 @@ export interface ICompanySpecificStartupProperties {
   middleware?: IAttachCompanySpecificMiddleware;
   administrationSection?: ICorporationAdministrationSection;
   strings?: IAttachCompanySpecificStrings;
+  features?: ICompanySpecificFeatures;
 }
 
 export interface IAttachCompanySpecificMiddleware {

--- a/lib/graphProvider/index.ts
+++ b/lib/graphProvider/index.ts
@@ -65,6 +65,7 @@ export interface IGraphProvider {
   getGroupsStartingWith(minimum3Characters: string): Promise<IGraphGroup[]>;
   getGroupMembers(corporateGroupId: string): Promise<IGraphGroupMember[]>;
   getGroup(corporateGroupId: string): Promise<IGraphGroup>;
+  isUserInGroup(corporateId: string, securityGroupId: string): Promise<boolean>;
 
   getToken(): Promise<string>;
 }

--- a/lib/graphProvider/microsoftGraphProvider.ts
+++ b/lib/graphProvider/microsoftGraphProvider.ts
@@ -55,6 +55,12 @@ export class MicrosoftGraphProvider implements IGraphProvider {
     }
   }
 
+  async isUserInGroup(corporateId: string, securityGroupId: string): Promise<boolean> {
+    // TODO: refactor for efficient use of Microsoft Graph's checkMemberObjects https://docs.microsoft.com/en-us/graph/api/group-checkmemberobjects?view=graph-rest-1.0&tabs=http
+    const members = await this.getGroupMembers(securityGroupId);
+    return members.filter(m => m.id === corporateId).length > 0;
+  }
+
   getManagerById(aadId, callback) {
     this.getTokenThenEntity(aadId, 'manager', callback);
   }

--- a/middleware/github/orgPermissions.ts
+++ b/middleware/github/orgPermissions.ts
@@ -27,8 +27,9 @@ export async function AddOrganizationPermissionsToRequest(req: ReposAppRequest, 
   if (req[orgPermissionsCacheKeyName]) {
     return next();
   }
-  const login = req.individualContext.getGitHubIdentity().username;
-  const ghIdAsString = req.individualContext.getGitHubIdentity().id;
+  const individualContext = req.individualContext;
+  const login = individualContext.getGitHubIdentity().username;
+  const ghIdAsString = individualContext.getGitHubIdentity().id;
   const id = ghIdAsString ? parseInt(ghIdAsString, 10) : null;
   const organization = req.organization;
   const orgPermissions: IRequestOrganizationPermissions = {
@@ -41,8 +42,8 @@ export async function AddOrganizationPermissionsToRequest(req: ReposAppRequest, 
     return next(new Error(`While your technical GitHub ID ${id} is known, your GitHub username is not currently known.`));
   }
   req[orgPermissionsCacheKeyName] = orgPermissions;
-  const isSudoer = await organization.isSudoer(login);
-  const isPortalSudoer = await req.individualContext.isPortalAdministrator();
+  const isSudoer = await organization.isSudoer(login, individualContext.link);
+  const isPortalSudoer = await individualContext.isPortalAdministrator();
 
   // Indicate that the user is has sudo rights
   if (isSudoer === true || isPortalSudoer === true) {

--- a/middleware/github/repoPermissions.ts
+++ b/middleware/github/repoPermissions.ts
@@ -53,7 +53,7 @@ export async function getComputedRepositoryPermissions(providers: IProviders, ac
   repoPermissions.isLinked = true;
   const login = activeContext.getGitHubIdentity().username;
   const organization = repository.organization;
-  const isSudoer = await organization.isSudoer(login);
+  const isSudoer = await organization.isSudoer(login, activeContext.link);
   const isPortalSudoer = await activeContext.isPortalAdministrator();
   if (isSudoer === true || isPortalSudoer === true) {
     repoPermissions.sudo = true;

--- a/middleware/github/teamPermissions.ts
+++ b/middleware/github/teamPermissions.ts
@@ -101,7 +101,7 @@ export async function AddTeamPermissionsToRequest(req: ReposAppRequest, res, nex
     if (!organization) {
       return next(new Error('organization required'));
     }
-    const isSudoer = await organization.isSudoer(login);
+    const isSudoer = await organization.isSudoer(login, activeContext.link);
     const isPortalSudoer = await activeContext.isPortalAdministrator();
 
     // Indicate that the user is has sudo rights

--- a/routes/settings/approvals.ts
+++ b/routes/settings/approvals.ts
@@ -129,7 +129,7 @@ router.get('/:requestid', asyncHandler(async function (req: ReposAppRequest, res
     organization = operations.getOrganization(pendingRequest.organizationName);
     team2 = organization.team(Number(pendingRequest.teamId));
     await team2.getDetails();
-    const isOrgSudoer = await organization.isSudoer(username);
+    const isOrgSudoer = await organization.isSudoer(username, req.individualContext?.link);
     isMaintainer = isOrgSudoer;
     const maintainers = await team2.getOfficialMaintainers();
     if (!isMaintainer) {


### PR DESCRIPTION
Adds support for organization sudo privileges to flow from
security groups instead of from GitHub Teams as the source of
truth.

Sudo remains on by default and configured for teams.

Also provides for company-specific overrides if you have a
different system for authorization decisions that is not part
of the default kit.