### PR TITLE
Refactor provider instance get

### DIFF
--- a/api/client/banner.ts
+++ b/api/client/banner.ts
@@ -5,15 +5,15 @@
 
 import express from 'express';
 
-import { jsonError } from '../../middleware/jsonError';
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { jsonError } from '../../middleware';
+import { getProviders, ReposAppRequest } from '../../transitional';
 
 const router = express.Router();
 
 // TODO: move to modern w/administration experience, optionally
 
 router.get('/', (req: ReposAppRequest, res, next) => {
-  const { config } = req.app.settings.providers as IProviders;
+  const { config } = getProviders(req);
   const text = config?.serviceMessage?.banner || null;
   const link = config.serviceMessage?.link;
   const details = config.serviceMessage?.details;

--- a/api/client/context/approvals.ts
+++ b/api/client/context/approvals.ts
@@ -10,7 +10,7 @@ import { TeamJsonFormat, Team, Organization } from '../../../business';
 import { TeamJoinApprovalEntity } from '../../../entities/teamJoinApproval/teamJoinApproval';
 import { jsonError } from '../../../middleware';
 import { ApprovalPair, Approvals_getTeamMaintainerApprovals, Approvals_getUserRequests, closeOldRequest } from '../../../routes/settings/approvals';
-import { ReposAppRequest, IProviders } from '../../../transitional';
+import { ReposAppRequest, getProviders } from '../../../transitional';
 import { IndividualContext } from '../../../user';
 
 const router = express.Router();
@@ -23,7 +23,7 @@ const approvalPairToJson = (pair: ApprovalPair) => {
 };
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const { approvalProvider, operations } = req.app.settings.providers as IProviders;
+  const { approvalProvider, operations } = getProviders(req);
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
   if (!activeContext.link) {
     return res.json({
@@ -56,7 +56,7 @@ router.get('/:approvalId', asyncHandler(async (req: ReposAppRequest, res, next) 
   if (!activeContext.link) {
     return res.json({});
   }
-  const { approvalProvider, operations } = req.app.settings.providers as IProviders;
+  const { approvalProvider, operations } = getProviders(req);
   const corporateId = activeContext.corporateIdentity.id;
   let request: TeamJoinApprovalEntity = null;
   try {

--- a/api/client/context/index.ts
+++ b/api/client/context/index.ts
@@ -10,7 +10,7 @@ import { Organization } from '../../../business';
 
 import { jsonError } from '../../../middleware';
 import getCompanySpecificDeployment from '../../../middleware/companySpecificDeployment';
-import { ErrorHelper, IProviders, ReposAppRequest } from '../../../transitional';
+import { ErrorHelper, getProviders, IProviders, ReposAppRequest } from '../../../transitional';
 import { IndividualContext } from '../../../user';
 
 import RouteApprovals from './approvals';
@@ -27,7 +27,7 @@ deployment?.routes?.api?.context?.index && deployment?.routes?.api?.context?.ind
 router.use('/approvals', RouteApprovals);
 
 router.get('/', (req: ReposAppRequest, res) => {
-  const { config } = req.app.settings.providers as IProviders;
+  const { config } = getProviders(req);
   const { continuousDeployment } = config;
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
   const isGitHubAuthenticated = !!activeContext.getSessionBasedGitHubIdentity()?.id;
@@ -43,7 +43,7 @@ router.get('/', (req: ReposAppRequest, res) => {
 });
 
 router.get('/accountDetails', asyncHandler(async (req: ReposAppRequest, res) => {
-  const { operations} = req.app.settings.providers as IProviders;
+  const { operations} = getProviders(req);
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
   const gh = activeContext.getGitHubIdentity();
   if (!gh || !gh.id) {
@@ -63,7 +63,7 @@ router.get('/teams', RouteTeams);
 
 router.use('/orgs/:orgName', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { orgName } = req.params;
-  const { operations } = req.app.settings.providers as  IProviders;
+  const { operations } = getProviders(req);
   // const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
   // if (!activeContext.link) {
   //   return next(jsonError('Account is not linked', 400));

--- a/api/client/index.ts
+++ b/api/client/index.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { apiContextMiddleware, AddLinkToRequest, requireAccessTokenClient, setIdentity, jsonError } from '../../middleware';
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 
 import getCompanySpecificDeployment from '../../middleware/companySpecificDeployment';
 
@@ -25,7 +25,7 @@ import RouteCrossOrganizationTeams from './teams';
 const router = express.Router();
 
 router.use((req: ReposAppRequest, res, next) => {
-  const { config } = req.app.settings.providers as IProviders;
+  const { config } = getProviders(req);
   if (config?.features?.allowApiClient) {
     return req.isAuthenticated() ? next() : next(jsonError('Session is not authenticated', 401));
   }

--- a/api/client/linking.ts
+++ b/api/client/linking.ts
@@ -8,7 +8,7 @@ import asyncHandler from 'express-async-handler';
 
 import { IndividualContext } from '../../user';
 import { jsonError } from '../../middleware';
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import { unlinkInteractive } from '../../routes/unlink';
 import { interactiveLinkUser } from '../../routes/link';
 
@@ -16,7 +16,7 @@ const router = express.Router();
 
 async function validateLinkOk(req: ReposAppRequest, res, next) {
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const insights = providers.insights;
   const config = providers.config;
   let validateAndBlockGuests = false;

--- a/api/client/newRepo.ts
+++ b/api/client/newRepo.ts
@@ -4,7 +4,7 @@
 //
 
 import express from 'express';
-import { ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import { jsonError } from '../../middleware/jsonError';
 
 import newOrgRepo from './newOrgRepo';
@@ -12,7 +12,7 @@ const router = express.Router();
 
 router.use('/org/:org', (req: ReposAppRequest, res, next) => {
   const orgName = req.params.org;
-  const operations = req.app.settings.providers.operations;
+  const { operations } = getProviders(req);
   try {
     req.organization = operations.getOrganization(orgName);
   } catch (noOrganization) {

--- a/api/client/organization/people.ts
+++ b/api/client/organization/people.ts
@@ -6,17 +6,11 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { jsonError } from '../../../middleware/jsonError';
-import { IProviders, NoCacheNoBackground, ReposAppRequest } from '../../../transitional';
-import { Organization } from '../../../business/organization';
-import { MemberSearch } from '../../../business/memberSearch';
-import { Operations } from '../../../business/operations';
-import { corporateLinkToJson } from '../../../business/corporateLink';
-import { OrganizationMember } from '../../../business/organizationMember';
-import { Team } from '../../../business/team';
-import { TeamMember } from '../../../business/teamMember';
+import { jsonError } from '../../../middleware';
+import { getProviders, NoCacheNoBackground, ReposAppRequest } from '../../../transitional';
 import LeakyLocalCache, { getLinksLightCache } from '../leakyLocalCache';
 import JsonPager from '../jsonPager';
+import { OrganizationMember, TeamMember, Operations, Team, Organization, MemberSearch, corporateLinkToJson } from '../../../business';
 
 const router = express.Router();
 
@@ -59,7 +53,7 @@ type PeopleSearchOptions = {
 }
 
 export async function equivalentLegacyPeopleSearch(req: ReposAppRequest, options?: PeopleSearchOptions) {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const links = await getLinksLightCache(operations);
   const org = req.organization ? req.organization.name : null;
   const orgId = req.organization ? (req.organization as Organization).id : null;

--- a/api/client/organization/repos.ts
+++ b/api/client/organization/repos.ts
@@ -6,9 +6,9 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { jsonError } from '../../../middleware/jsonError';
-import { IProviders, ReposAppRequest } from '../../../transitional';
-import { Repository } from '../../../business/repository';
+import { jsonError } from '../../../middleware';
+import { getProviders, IProviders, ReposAppRequest } from '../../../transitional';
+import { Repository } from '../../../business';
 
 import RouteRepo from './repo';
 import JsonPager from '../jsonPager';
@@ -17,7 +17,7 @@ const router = express.Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { organization } = req;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const pager = new JsonPager<Repository>(req, res);
   const searchOptions = {
     q: (req.query.q || '') as string,

--- a/api/client/organization/team.ts
+++ b/api/client/organization/team.ts
@@ -5,18 +5,16 @@
 
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { corporateLinkToJson, ICorporateLink } from '../../../business/corporateLink';
-import { OrganizationMember } from '../../../business/organizationMember';
-import { TeamJsonFormat } from '../../../business/team';
-import { TeamRepositoryPermission } from '../../../business/teamRepositoryPermission';
+
 import { getContextualTeam } from '../../../middleware/github/teamPermissions';
 
-import { jsonError } from '../../../middleware/jsonError';
+import { jsonError } from '../../../middleware';
 import { sortRepositoriesByNameCaseInsensitive } from '../../../routes/org/team';
-import { IProviders, NoCacheNoBackground, ReposAppRequest } from '../../../transitional';
+import { getProviders, NoCacheNoBackground, ReposAppRequest } from '../../../transitional';
 import JsonPager from '../jsonPager';
 import { getLinksLightCache } from '../leakyLocalCache';
 import { equivalentLegacyPeopleSearch } from './people';
+import { TeamJsonFormat, TeamRepositoryPermission, OrganizationMember, corporateLinkToJson, ICorporateLink } from '../../../business';
 
 const router = express.Router();
 
@@ -68,7 +66,7 @@ router.get('/members', asyncHandler(async (req: ReposAppRequest, res, next) => {
 }));
 
 router.get('/maintainers', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   try {
     const forceRefresh = !!req.query.refresh;
     const team = getContextualTeam(req);

--- a/api/client/organizations.ts
+++ b/api/client/organizations.ts
@@ -6,15 +6,15 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { jsonError } from '../../middleware/jsonError';
-import { ErrorHelper, IProviders, ReposAppRequest } from '../../transitional';
+import { jsonError } from '../../middleware';
+import { ErrorHelper, getProviders, ReposAppRequest } from '../../transitional';
 
 import RouteOrganization from './organization';
 
 const router = express.Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   try {
     const orgs = operations.getOrganizations();
     const dd = orgs.map(org => { return org.asClientJson(); });
@@ -25,7 +25,7 @@ router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
 }));
 
 router.use('/:orgName', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const { orgName } = req.params;
   try {
     const org = operations.getOrganization(orgName);

--- a/api/client/peopleSearch.ts
+++ b/api/client/peopleSearch.ts
@@ -4,7 +4,7 @@
 //
 
 import { Organization, MemberSearch, ICrossOrganizationMembersResult, Operations } from '../../business';
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import LeakyLocalCache, { getLinksLightCache } from './leakyLocalCache';
 
 // BAD PRACTICE: leaky local cache
@@ -22,7 +22,7 @@ export async function getPeopleAcrossOrganizations(operations: Operations) {
 }
 
 export async function equivalentLegacyPeopleSearch(req: ReposAppRequest) {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const links = await getLinksLightCache(operations);
   const org = req.organization ? req.organization.name : null;
   const orgId = req.organization ? (req.organization as Organization).id : null;

--- a/api/client/person.ts
+++ b/api/client/person.ts
@@ -5,13 +5,13 @@
 
 import asyncHandler from 'express-async-handler';
 
-import { jsonError } from '../../middleware/jsonError';
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { jsonError } from '../../middleware';
+import { getProviders, ReposAppRequest } from '../../transitional';
 
 import { AccountJsonFormat } from '../../business';
 
 export default asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const { operations, queryCache } = providers;
   const login = req.params.login as string;
   try {

--- a/api/client/repos.ts
+++ b/api/client/repos.ts
@@ -5,18 +5,17 @@
 
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { Repository } from '../../business/repository';
 
-import { jsonError } from '../../middleware/jsonError';
-import { IProviders, ReposAppRequest } from '../../transitional';
-
+import { Repository } from '../../business';
+import { jsonError } from '../../middleware';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import JsonPager from './jsonPager';
 import { RepositorySearchSortOrder, searchRepos } from './organization/repos';
 
 const router = express.Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const pager = new JsonPager<Repository>(req, res);
   const searchOptions = {
     q: (req.query.q || '') as string,

--- a/api/client/teams.ts
+++ b/api/client/teams.ts
@@ -5,12 +5,10 @@
 
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { ICrossOrganizationMembershipByOrganization, Operations } from '../../business/operations';
-import { Team, TeamJsonFormat } from '../../business/team';
 
-import { jsonError } from '../../middleware/jsonError';
-import { IProviders, ReposAppRequest } from '../../transitional';
-
+import { ICrossOrganizationMembershipByOrganization, Operations, Team, TeamJsonFormat } from '../../business';
+import { jsonError } from '../../middleware';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import JsonPager from './jsonPager';
 
 const router = express.Router();
@@ -36,7 +34,7 @@ async function getCrossOrganizationTeams(operations: Operations): Promise<Team[]
 }
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const pager = new JsonPager<Team>(req, res);
   const q: string = (req.query.q ? req.query.q as string : null) || '';
   try {

--- a/api/extension.ts
+++ b/api/extension.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { IProviders } from '../transitional';
+import { getProviders, IProviders } from '../transitional';
 import { setIdentity } from '../middleware/business/authentication';
 import { AddLinkToRequest } from '../middleware/links';
 import { jsonError } from '../middleware';
@@ -66,7 +66,7 @@ router.use(asyncHandler(AddLinkToRequest));
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 router.get('/', (req: IApiRequest, res) => {
-  const operations = req.app.settings.providers.operations;
+  const { operations } = getProviders(req);
 
   // Basic info route, used to validate new users
   const apiContext = req.apiContext;
@@ -122,7 +122,7 @@ router.get('/metadata', asyncHandler(getLocalEncryptionKeyMiddleware), (req: IAp
   const apiContext = req.apiContext;
 
   const localKey = res.localKey;
-  const operations = req.app.settings.providers.operations;
+  const { operations } = getProviders(req);
   const ghi = apiContext.getGitHubIdentity();
   const id = ghi ? ghi.id : null;
   const login = ghi ? ghi.username : null;
@@ -183,7 +183,7 @@ function getSanitizedOrganizations(operations) {
 }
 
 async function getLocalEncryptionKeyMiddleware(req: IApiRequest, res, next): Promise<void> {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const localExtensionKeyProvider = providers.localExtensionKeyProvider;
   const apiKeyToken = req.apiKeyToken;
   const insights = req.insights;

--- a/api/index.ts
+++ b/api/index.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 
 import cors from 'cors';
 
-import { ReposAppRequest, IProviders } from '../transitional';
+import { ReposAppRequest, getProviders } from '../transitional';
 
 import { jsonError } from '../middleware';
 import { IApiRequest } from '../middleware/apiReposAuth';
@@ -91,7 +91,7 @@ router.use('/:org', function (req: IApiRequest, res, next) {
     return next(jsonError('The key is not authorized to use the repo create APIs', 401));
   }
 
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
   let organization = null;
   try {
@@ -104,7 +104,7 @@ router.use('/:org', function (req: IApiRequest, res, next) {
 });
 
 router.post('/:org/repos', asyncHandler(async function (req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const convergedObject = Object.assign({}, req.headers);
   req.insights.trackEvent({ name: 'ApiRepoCreateRequest', properties: convergedObject });
   Object.assign(convergedObject, req.body);

--- a/api/jsonErrorHandler.ts
+++ b/api/jsonErrorHandler.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { IProviders } from '../transitional';
+import { getProviders } from '../transitional';
 
 export default function JsonErrorHandler(err, req, res, next) {
   if (err && err['json']) {
@@ -20,7 +20,7 @@ export default function JsonErrorHandler(err, req, res, next) {
   res.json({
     message: err && err.message ? err.message : 'Error',
   });
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   if (providers && providers.insights) {
     providers.insights.trackException({ exception: err });
   }

--- a/api/people/link.ts
+++ b/api/people/link.ts
@@ -3,11 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { IProviders } from '../../transitional';
-import { jsonError } from '../../middleware/jsonError';
+import { getProviders } from '../../transitional';
+import { jsonError } from '../../middleware';
 import { IApiRequest } from '../../middleware/apiReposAuth';
-import { ICorporateLink } from '../../business/corporateLink';
-import { LinkOperationSource } from '../../business/operations';
+import { ICorporateLink, LinkOperationSource } from '../../business';
 
 const linkScope = 'link';
 
@@ -16,7 +15,7 @@ const supportedApiVersions = new Set([
 ]);
 
 export default async function postLinkApi(req: IApiRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const { operations } = providers;
   const token = req.apiKeyToken;
   const apiVersion = (req.query['api-version'] || req.headers['api-version']) as string;

--- a/api/people/links.ts
+++ b/api/people/links.ts
@@ -12,7 +12,7 @@ import { ICorporateLink } from '../../business/corporateLink';
 import { Operations, ICrossOrganizationMembersResult } from '../../business/operations';
 import { IApiRequest } from '../../middleware/apiReposAuth';
 import postLinkApi from './link';
-import { ErrorHelper } from '../../transitional';
+import { ErrorHelper, getProviders } from '../../transitional';
 import { wrapError } from '../../utils';
 
 const router = express.Router();
@@ -39,7 +39,7 @@ router.use(function (req: IApiRequest, res, next) {
 router.post('/', asyncHandler(postLinkApi));
 
 router.get('/', asyncHandler(async (req: IApiRequest, res, next) => {
-  const operations = req.app.settings.operations;
+  const { operations } = getProviders(req);
   const skipOrganizations = req.query.showOrganizations !== undefined && !!req.query.showOrganizations;
   const showTimestamps = req.query.showTimestamps !== undefined && req.query.showTimestamps === 'true';
   const results = await getAllUsers(req.apiVersion, operations, skipOrganizations, showTimestamps);
@@ -53,7 +53,7 @@ router.get('/:linkid', asyncHandler(async (req: IApiRequest, res, next) => {
     return next(jsonError('This API is not supported by the API version you are using.', 400));
   }
   const linkid = req.params.linkid.toLowerCase();
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const skipOrganizations = req.query.showOrganizations !== undefined && !!req.query.showOrganizations;
   const showTimestamps = req.query.showTimestamps !== undefined && req.query.showTimestamps === 'true';
   if (operations.providers.queryCache && operations.providers.queryCache.supportsOrganizationMembership) {
@@ -93,7 +93,7 @@ router.get('/github/:username', asyncHandler(async (req: IApiRequest, res, next)
     return next(jsonError('This API is not supported by the API version you are using.', 400));
   }
   const username = req.params.username.toLowerCase();
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const skipOrganizations = req.query.showOrganizations !== undefined && !!req.query.showOrganizations;
   const showTimestamps = req.query.showTimestamps !== undefined && req.query.showTimestamps === 'true';
   if (operations.providers.queryCache && operations.providers.queryCache.supportsOrganizationMembership) {
@@ -128,7 +128,7 @@ router.get('/github/:username', asyncHandler(async (req: IApiRequest, res, next)
 
 router.get('/aad/userPrincipalName/:upn', asyncHandler(async (req: IApiRequest, res, next) => {
   const upn = req.params.upn;
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const skipOrganizations = req.query.showOrganizations !== undefined && !!req.query.showOrganizations;
   const showTimestamps = req.query.showTimestamps !== undefined && req.query.showTimestamps === 'true';
   if (operations.providers.queryCache && operations.providers.queryCache.supportsOrganizationMembership) {
@@ -184,7 +184,7 @@ router.get('/aad/:id', asyncHandler(async (req: IApiRequest, res, next) => {
   const id = req.params.id;
   const skipOrganizations = req.query.showOrganizations !== undefined && !!req.query.showOrganizations;
   const showTimestamps = req.query.showTimestamps !== undefined && req.query.showTimestamps === 'true';
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   if (operations.providers.queryCache && operations.providers.queryCache.supportsOrganizationMembership) {
     // faster implementation
     const links = await operations.providers.linkProvider.queryByCorporateId(id);

--- a/api/people/unlink.ts
+++ b/api/people/unlink.ts
@@ -6,10 +6,10 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { jsonError } from '../../middleware/jsonError';
-import { ICorporateLink } from '../../business/corporateLink';
-import { Operations, UnlinkPurpose } from '../../business/operations';
+import { jsonError } from '../../middleware';
+import { ICorporateLink, UnlinkPurpose } from '../../business';
 import { IApiRequest } from '../../middleware/apiReposAuth';
+import { getProviders } from '../../transitional';
 
 const router = express.Router();
 
@@ -29,9 +29,8 @@ router.use(function (req: ILinksApiRequestWithUnlink, res, next) {
 });
 
 router.use('/github/id/:id', asyncHandler(async (req: ILinksApiRequestWithUnlink, res, next) => {
+  const { operations } = getProviders(req);
   const id = req.params.id;
-
-  const operations = req.app.settings.operations as Operations;
   try {
     const link = await operations.linkProvider.getByThirdPartyId(id);
     if (!link) {
@@ -49,7 +48,7 @@ router.use('*', (req: ILinksApiRequestWithUnlink, res, next) => {
 });
 
 router.delete('*', (req: ILinksApiRequestWithUnlink, res, next) => {
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const link = req.unlink;
   let purpose: UnlinkPurpose = null;
   try {

--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -5,25 +5,27 @@
 
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { jsonError } from '../middleware';
 
 import moment from 'moment';
-import { ReposAppRequest } from '../transitional';
-const router = express.Router();
+
+import { jsonError } from '../middleware';
+import { getProviders, ReposAppRequest } from '../transitional';
 
 import OrganizationWebhookProcessor from '../webhooks/organizationProcessor';
+
+const router = express.Router();
 
 interface IRequestWithRaw extends ReposAppRequest {
   _raw?: any;
 }
 
 router.use(asyncHandler(async (req: IRequestWithRaw, res, next) => {
+  const { operations } = getProviders(req);
   const body = req.body;
   const orgName = body && body.organization && body.organization.login ? body.organization.login : null;
   if (!orgName) {
     return next(jsonError(new Error('No organization login in the body'), 400));
   }
-  const operations = req.app.settings.providers.operations;
   try {
     if (!req.organization) {
       req.organization = operations.getOrganization(orgName);

--- a/middleware/apiAad.ts
+++ b/middleware/apiAad.ts
@@ -9,7 +9,7 @@ import jwksClient from 'jwks-rsa';
 import { isJsonError, jsonError } from './jsonError';
 import { IApiRequest, wrapErrorForImmediateUserError } from './apiReposAuth';
 import { PersonalAccessToken } from '../entities/token/token';
-import { IProviders } from '../transitional';
+import { getProviders } from '../transitional';
 
 // TODO: Caching of signing keys
 
@@ -58,7 +58,7 @@ function getSigningKeys(header, callback) {
 }
 
 async function validateAadAuthorization(req: IApiRequest): Promise<void> {
-  const { config, insights } = req.app.settings.providers as IProviders;
+  const { config, insights } = getProviders(req);
 
   const allowedTenants = (config?.microsoft?.api?.aad?.authorizedTenants || '').split(',');
   if (!allowedTenants) {

--- a/middleware/apiVstsAuth.ts
+++ b/middleware/apiVstsAuth.ts
@@ -8,13 +8,13 @@ import request = require('requestretry');
 import { jsonError } from './jsonError';
 import { IApiRequest } from './apiReposAuth';
 import { PersonalAccessToken } from '../entities/token/token';
-import { IProviders } from '../transitional';
+import { getProviders } from '../transitional';
 
 // TODO: consider better caching
 const localMemoryCacheVstsToAadId = new Map();
 
 export function AzureDevOpsAuthenticationMiddleware(req: IApiRequest, res, next) {
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   if (!config) {
     return next(new Error('Missing configuration for the application'));
   }
@@ -28,7 +28,7 @@ export function AzureDevOpsAuthenticationMiddleware(req: IApiRequest, res, next)
     return next(new Error('VSTS collection URL is missing in the environment configuration'));
   }
 
-  const { graphProvider } = req.app.settings.providers as IProviders;
+  const { graphProvider } = getProviders(req);
 
   const vstsCollectionUrl = config.authentication.vsts.vstsCollectionUrl;
   const connectionDataApi = `${vstsCollectionUrl}/_apis/connectiondata`;

--- a/middleware/business/allLinks.ts
+++ b/middleware/business/allLinks.ts
@@ -3,9 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import { wrapError } from '../../utils';
-import { Operations } from '../../business/operations';
 
 const cachedLinksRequestKeyName = 'cachedLinks';
 
@@ -13,7 +12,7 @@ export async function ensureAllLinksInMemory(req: ReposAppRequest, res, next) {
   if (req[cachedLinksRequestKeyName]) {
     return next();
   }
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   try {
     const links = await operations.getLinks();
     req[cachedLinksRequestKeyName] = links;

--- a/middleware/business/corporateAdministrators.ts
+++ b/middleware/business/corporateAdministrators.ts
@@ -6,9 +6,7 @@
 // This route does not use the portal administrator team but instead an explicit
 // approved list of corporate usernames.
 
-import express from 'express';
-
-import { ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 
 import { wrapError } from '../../utils';
 
@@ -18,7 +16,7 @@ function denyRoute(next) {
 
 export function AuthorizeOnlyCorporateAdministrators(req: ReposAppRequest, res, next) {
   const individualContext = req.individualContext;
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   const administrators: string[] = config && config.administrators && config.administrators.corporateUsernames ? config.administrators.corporateUsernames : null;
   const username = individualContext.corporateIdentity.username;
   let isAuthorized = false;

--- a/middleware/business/corporateAlias.ts
+++ b/middleware/business/corporateAlias.ts
@@ -3,13 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { getProviders, ReposAppRequest } from '../../transitional';
 import { IndividualContext } from '../../user';
 import { jsonError } from '../jsonError';
 
 export default async function getCorporateAliasFromActiveContext(req: ReposAppRequest) {
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
-  const { graphProvider } = req.app.settings.providers as IProviders;
+  const { graphProvider } = getProviders(req);
   if (!activeContext.corporateIdentity || !activeContext.corporateIdentity.id) {
     throw jsonError('No corporate identity', 401);
   }

--- a/middleware/campaign.ts
+++ b/middleware/campaign.ts
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+import { getProviders } from '../transitional';
+
 interface ICampaignData {
   uri?: any;
   sub?: any;
@@ -55,7 +57,7 @@ export default function initializeCampaigns(app) {
       return;
     }
 
-    const providers = req.app.settings.providers;
+    const providers = getProviders(req);
     const insights = providers.insights;
     if (!insights) {
       return;
@@ -101,7 +103,7 @@ export default function initializeCampaigns(app) {
       const uri = `${base}${prefixPortion}${identity}${sub}${queryPortion}`;
       res.redirect(uri);
 
-      const insights = req.app.settings.providers.insights;
+      const { insights } = getProviders(req);
       if (goGithubQuery) {
         data.query = goGithubQuery;
       }

--- a/middleware/errorHandler.ts
+++ b/middleware/errorHandler.ts
@@ -1,7 +1,3 @@
-import { wrapError } from "../utils";
-import { IProviders } from "../transitional";
-import { AxiosError } from "axios";
-
 //
 // Copyright (c) Microsoft.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -9,7 +5,11 @@ import { AxiosError } from "axios";
 
 /*eslint no-console: ["error", { allow: ["error", "log"] }] */
 
-const querystring = require('querystring');
+import querystring from 'querystring';
+import { AxiosError } from 'axios';
+
+import { wrapError } from '../utils';
+import { getProviders } from '../transitional';
 
 function redactRootPathsFromString(string, path) {
   if (typeof string === 'string' && string.includes && string.split) {
@@ -51,8 +51,7 @@ const exceptionFieldsOfInterest = [
 
 export default function SiteErrorHandler (err, req, res, next) {
   // CONSIDER: Let's eventually decouple all of our error message improvements to another area to keep the error handler intact.
-  const { applicationProfile } = req.app.settings.providers as IProviders;
-  var config = null;
+  const { applicationProfile, config } = getProviders(req);
   var correlationId = req.correlationId;
   var errorStatus = err ? (err.status || err.statusCode) : undefined;
   // Per GitHub: https://developer.github.com/v3/oauth/#bad-verification-code
@@ -73,8 +72,7 @@ export default function SiteErrorHandler (err, req, res, next) {
     err = wrapError(err, 'The GitHub API is temporarily down. Please try again soon.', false);
   }
   var primaryUserInstance = req.user ? req.user.github : null;
-  if (req && req.app && req.app.settings && req.app.settings.runtimeConfig) {
-    config = req.app.settings.runtimeConfig;
+  if (config) {
     if (config.authentication.scheme !== 'github') {
       primaryUserInstance = req.user ? req.user.azure : null;
     }

--- a/middleware/github/repoPermissions.ts
+++ b/middleware/github/repoPermissions.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import { IProviders, ReposAppRequest } from '../../transitional';
+import { getProviders, IProviders, ReposAppRequest } from '../../transitional';
 import { Repository } from '../../business/repository';
 import { IndividualContext } from '../../user';
 import { GitHubCollaboratorPermissionLevel } from '../../business/repositoryPermission';
@@ -85,7 +85,7 @@ export async function AddRepositoryPermissionsToRequest(req: ReposAppRequest, re
   }
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
   const repository = req[requestScopedRepositoryKeyName] as Repository;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const permissions = await getComputedRepositoryPermissions(providers, activeContext, repository);
   req[repoPermissionsCacheKeyName] = permissions;
   return next();

--- a/middleware/locals.ts
+++ b/middleware/locals.ts
@@ -5,18 +5,17 @@
 
 import os from 'os';
 
-// ----------------------------------------------------------------------------
-// Set local variables that we want every view to share.
-// ----------------------------------------------------------------------------
-export default function (req, res, next) {
+import { getProviders, ReposAppRequest } from '../transitional';
+
+export default function (req: ReposAppRequest, res, next) {
+  const { config, viewServices } = getProviders(req);
   req.app.locals.correlationId = req.correlationId;
   req.app.locals.scrubbedUrl = req.scrubbedUrl;
   req.app.locals.serverAddress = req.hostname;
   req.app.locals.serverName = os.hostname();
   req.app.locals.websiteHostname = process.env.WEBSITE_HOSTNAME;
-  req.app.locals.appInsightsKey = req.app.settings && req.app.settings.runtimeConfig && req.app.settings.runtimeConfig.telemetry ? req.app.settings.runtimeConfig.telemetry.applicationInsightsKey : null;
-  req.app.locals.googleAnalyticsKey = req.app.settings && req.app.settings.runtimeConfig && req.app.settings.runtimeConfig.telemetry ? req.app.settings.runtimeConfig.telemetry.googleAnalyticsKey : null;
-  req.app.locals.viewServices = req.app.settings.viewServices;
-
+  req.app.locals.appInsightsKey = config?.telemetry?.applicationInsightsKey;
+  req.app.locals.googleAnalyticsKey = config?.telemetry?.googleAnalyticsKey;
+  req.app.locals.viewServices = viewServices;
   return next();
 };

--- a/middleware/logger.ts
+++ b/middleware/logger.ts
@@ -4,14 +4,15 @@
 //
 
 import logger from 'morgan';
-import { ReposAppRequest } from '../transitional';
+
+import { getProviders, ReposAppRequest } from '../transitional';
 
 const encryptionMetadataKey = '_ClientEncryptionMetadata2';
 const piiFormat = ':id :method :scrubbedUrl :status :response-time ms - :res[content-length] :encryptedSession :correlationId';
 const format = ':method :scrubbedUrl :status :response-time ms - :res[content-length] :encryptedSession :correlationId';
 
 logger.token('encryptedSession', function getUserId(req: ReposAppRequest) {
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   if (req.session) {
     const sessionPassport = (req.session as any).passport;
     if (sessionPassport && sessionPassport.user) {
@@ -22,7 +23,7 @@ logger.token('encryptedSession', function getUserId(req: ReposAppRequest) {
 });
 
 logger.token('id', function getUserId(req: ReposAppRequest) {
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   if (config) {
     const userType = config.authentication.scheme === 'aad' ? 'azure' : 'github';
     return req.user && req.user[userType] && req.user[userType].username ? req.user[userType].username : undefined;

--- a/middleware/officeHyperlinks.ts
+++ b/middleware/officeHyperlinks.ts
@@ -1,8 +1,11 @@
 //
 // Copyright (c) Microsoft.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 // I no longer believe this file FYI... I don't think we need this any longer.
+
+import { getProviders } from '../transitional';
 
 // Office uses a specialized pre-fetch to learn more about hyperlinks before
 // opening. As a result, if the Office user agent is in use, and the
@@ -15,22 +18,20 @@ const GenericOfficeUserAgent = 'ms-office';
 const WordUserAgent = 'Microsoft Office Word';
 
 export default function supportOfficeHyperlinks(req, res, next) {
+  const { insights } = getProviders(req);
   const userAgent = req.headers['user-agent'];
   const isAuthenticated = req.isAuthenticated ? req.isAuthenticated() : false;
   if (userAgent && userAgent.includes && !isAuthenticated && (userAgent.includes(GenericOfficeUserAgent) || userAgent.includes(WordUserAgent))) {
-    const insights = req.insights || (req.app && req.app.settings && req.app.settings.providers ? req.app.settings.providers.insights : null);
-    if (insights) {
-      insights.trackEvent({
-        name: 'InterceptOfficeHyperlinkRequest',
-        properties: {
-          userAgent: userAgent,
-          isAuthenticated: isAuthenticated,
-          originalUrl: req.originalUrl,
-          httpMethod: req.method,
-          responseType: 200,
-        },
-      });
-    }
+    insights?.trackEvent({
+      name: 'InterceptOfficeHyperlinkRequest',
+      properties: {
+        userAgent: userAgent,
+        isAuthenticated: isAuthenticated,
+        originalUrl: req.originalUrl,
+        httpMethod: req.method,
+        responseType: 200,
+      },
+    });
     return res.send(`When using Microsoft Office, you need to open the hyperlink in your browser to authenticate if needed`);
   }
   return next();

--- a/middleware/react.ts
+++ b/middleware/react.ts
@@ -3,14 +3,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import path from 'path';
+import express from 'express';
 import fs from 'fs';
+import path from 'path';
 
 import appPackage from '../package.json';
 
 import { getStaticBlobCacheFallback } from '../lib/staticBlobCacheFallback';
-import { IProviders, ReposAppRequest } from '../transitional';
-import express from 'express';
+import { getProviders, ReposAppRequest } from '../transitional';
 
 const staticReactPackageNameKey = 'static-react-package-name';
 const staticClientPackageName = appPackage[staticReactPackageNameKey];
@@ -55,7 +55,7 @@ export async function TryFallbackToBlob(req: ReposAppRequest, res: express.Respo
   if (!req.path) {
     return false;
   }
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const baseUrl = '/react' + req.originalUrl;
   if (localFallbackBlobCache.has(baseUrl)) {
     providers.insights.trackEvent({name: 'FallbackToBlob', properties: { baseUrl }});

--- a/routes/administration/apps.ts
+++ b/routes/administration/apps.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { IProviders, ReposAppRequest, UserAlertType } from '../../transitional';
+import { getProviders, ReposAppRequest, UserAlertType } from '../../transitional';
 import { sortByCaseInsensitive } from '../../utils';
 import GitHubApplication from '../../business/application';
 import { OrganizationSetting } from '../../entities/organizationSettings/organizationSetting';
@@ -33,7 +33,7 @@ interface IByOrgView {
 }
 
 router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const { deletesettingsorgname } = req.body;
   if (!deletesettingsorgname) {
     return next(new Error('Not able to complete this operation'));
@@ -58,7 +58,7 @@ router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
 }));
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
   const apps = providers.operations.getApplications();
   const individualContext = req.individualContext;

--- a/routes/administration/index.ts
+++ b/routes/administration/index.ts
@@ -8,13 +8,13 @@ import asyncHandler from 'express-async-handler';
 import getCompanySpecificDeployment from '../../middleware/companySpecificDeployment';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 
 import RouteApp from './app';
 import RouteApps from './apps';
 
 router.use('*', asyncHandler(async function (req: ReposAppRequest, res, next) {
-  const { corporateAdministrationProfile } = req.app.settings.providers as IProviders;
+  const { corporateAdministrationProfile } = getProviders(req);
   if (corporateAdministrationProfile && corporateAdministrationProfile.urls) {
     req.individualContext.setInitialViewProperty('_corpAdminUrls', corporateAdministrationProfile.urls);
   }

--- a/routes/diagnostics.ts
+++ b/routes/diagnostics.ts
@@ -4,12 +4,13 @@
 //
 
 import express from 'express';
-import { IAppSession } from '../transitional';
+import { getProviders, IAppSession, ReposAppRequest } from '../transitional';
 const router = express.Router();
 
 const redacted = '*****';
 
 interface IRequestWithSession extends express.Request {
+  app: any;
   session: IAppSession;
   user: any;
 }
@@ -23,8 +24,8 @@ interface ISafeUserView {
 }
 
 router.get('/', (req: IRequestWithSession, res) => {
+  const { config } = getProviders(req as any as ReposAppRequest);
   const sessionPrefix = req['sessionStore'] && req['sessionStore'].prefix ? req['sessionStore'].prefix + ':' : null;
-  let config = req.app.settings.runtimeConfig;
   const sessionIndex = sessionPrefix ? `${sessionPrefix}${req.session.id}` : req.session.id;
   let safeUserView: ISafeUserView = {
     cookies: req.cookies,

--- a/routes/explore.ts
+++ b/routes/explore.ts
@@ -6,37 +6,39 @@
 import express from 'express';
 const router = express.Router();
 
-router.get('/', (req, res) => {
-  const config = req.app.settings.runtimeConfig.obfuscatedConfig;
+import { getProviders, ReposAppRequest } from '../transitional';
+
+router.get('/', (req: ReposAppRequest, res) => {
+  const config = getProviders(req).config;
   res.render('explore', {
-    config: config,
+    config: config.obfuscatedConfig,
     title: 'Explore',
     site: 'explore',
   });
 });
 
-router.get('/registration', (req, res) => {
-  const config = req.app.settings.runtimeConfig.obfuscatedConfig;
+router.get('/registration', (req: ReposAppRequest, res) => {
+  const config = getProviders(req).config;
   res.render('explore', {
-    config: config,
+    config: config.obfuscatedConfig,
     title: 'Witness',
     site: 'registration',
   });
 });
 
-router.get('/contribute', (req, res) => {
-  const config = req.app.settings.runtimeConfig.obfuscatedConfig;
+router.get('/contribute', (req: ReposAppRequest, res) => {
+  const config = getProviders(req).config;
   res.render('explore', {
-    config: config,
+    config: config.obfuscatedConfig,
     title: 'Contribute',
     site: 'contribute',
   });
 });
 
-router.get('/data', (req, res) => {
-  const config = req.app.settings.runtimeConfig.obfuscatedConfig;
+router.get('/data', (req: ReposAppRequest, res) => {
+  const config = getProviders(req).config;
   res.render('explore', {
-    config: config,
+    config: config.obfuscatedConfig,
     title: 'Data',
     site: 'data',
   });

--- a/routes/index-authenticated.ts
+++ b/routes/index-authenticated.ts
@@ -11,7 +11,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, UserAlertType, hasStaticReactClientApp } from '../transitional';
+import { ReposAppRequest, UserAlertType, hasStaticReactClientApp, getProviders } from '../transitional';
 
 import { Organization } from '../business/organization';
 
@@ -60,7 +60,7 @@ dynamicStartupInstance?.routes?.connectAuthenticatedRoutes && dynamicStartupInst
 router.use('/settings', SettingsRoute);
 
 router.get('/news', (req: ReposAppRequest, res, next) => {
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   if (config && config.news && config.news.all && config.news.all.length) {
     return req.individualContext.webContext.render({
       view: 'news',
@@ -79,9 +79,9 @@ router.get('/', reactRoute || asyncHandler(async function (req: ReposAppRequest,
   const onboarding = req.query.onboarding !== undefined;
   const individualContext = req.individualContext;
   const link = individualContext.link;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
-  const config = req.app.settings.runtimeConfig;
+  const config = getProviders(req).config;;
   if (!link) {
     if (!individualContext.getGitHubIdentity()) {
       return individualContext.webContext.render({

--- a/routes/index-linked.ts
+++ b/routes/index-linked.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, CreateError, hasStaticReactClientApp } from '../transitional';
+import { ReposAppRequest, CreateError, hasStaticReactClientApp, getProviders } from '../transitional';
 import { IndividualContext } from '../user';
 import { storeOriginalUrlAsVariable } from '../utils';
 import { AuthorizeOnlyCorporateAdministrators } from '../middleware/business/corporateAdministrators';
@@ -20,8 +20,7 @@ import RouteRepos from './repos';
 import RouteLegacyOrganizationAdministration from './orgAdmin';
 
 import unlinkRoute from './unlink';
-import { Organization } from '../business/organization';
-import { Repository } from '../business/repository';
+import { Organization, Repository } from '../business';
 
 import orgsRoute from './orgs';
 import { injectReactClient } from '../middleware';
@@ -63,10 +62,10 @@ router.use('/repos', reactRoute || RouteRepos);
 router.use('/undo', RouteUndo);
 router.use('/administration', AuthorizeOnlyCorporateAdministrators, RouteAdministration);
 
-router.use('/https?*github.com/:org/:repo', asyncHandler(async (req, res, next) => {
+router.use('/https?*github.com/:org/:repo', asyncHandler(async (req: ReposAppRequest, res, next) => {
   // Helper method to allow pasting a GitHub URL into the app to go to a repo
   const { org, repo } = req.params;
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   if (org && repo) {
     let organization: Organization = null;
     try {

--- a/routes/link-cleanup.ts
+++ b/routes/link-cleanup.ts
@@ -145,14 +145,14 @@ router.use((req: ReposAppRequest, res, next) => {
 // });
 
 // function unlink(req, link, callback) {
-//   const operations = req.app.settings.providers.operations;
+//   const { operations, insights, redisClient, config, githubLibrary } = getProviders(req);
 //   const options = {
-//     config: req.app.settings.runtimeConfig,
-//     redisClient: req.app.settings.providers.redisClient,
-//     githubLibrary: req.app.settings.githubLibrary,
-//     operations: operations,
-//     link: link,
-//     insights: req.insights,
+//     config,
+//     redisClient,
+//     githubLibrary,
+//     operations,
+//     link,
+//     insights,
 //   };
 //   new OpenSourceUserContext(options, function (contextError, unlinkContext) {
 //     if (contextError) {
@@ -161,23 +161,6 @@ router.use((req: ReposAppRequest, res, next) => {
 //     const account = operations.getAccount(unlinkContext.id.github);
 //     const reason = 'Link-cleanup, voluntary unlinking';
 //     account.terminate({ reason: reason }, callback);
-//   });
-// }
-
-// function invalidateCache(req, link, callback) {
-//   const options = {
-//     config: req.app.settings.runtimeConfig,
-//     redisClient: req.app.settings.providers.redisClient,
-//     githubLibrary: req.app.settings.githubLibrary,
-//     operations: req.app.settings.providers.operations,
-//     link: link,
-//     insights: req.insights,
-//   };
-//   new OpenSourceUserContext(options, function (contextError, unlinkContext) {
-//     if (contextError) {
-//       return callback(contextError);
-//     }
-//     return callback();
 //   });
 // }
 

--- a/routes/org/index.ts
+++ b/routes/org/index.ts
@@ -7,7 +7,7 @@ import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, IProviders, getProviders } from '../../transitional';
 import { Team } from '../../business/team';
 import { IRequestOrganizationPermissions, AddOrganizationPermissionsToRequest } from '../../middleware/github/orgPermissions';
 import { OrganizationMembershipState } from '../../business/organization';
@@ -42,10 +42,11 @@ router.use(function (req: ReposAppRequest, res, next) {
 
 // Campaign-related redirect to take the user to GitHub
 router.get('/', (req: ReposAppRequest, res, next) => {
-  if (!req.app.settings.providers || !req.app.settings.providers.campaign) {
+  const providers = getProviders(req);
+  if (!providers || !providers.campaign) {
     return next();
   }
-  return req.app.settings.providers.campaign.redirectGitHubMiddleware(req, res, next, () => {
+  return providers.campaign.redirectGitHubMiddleware(req, res, next, () => {
     return req.organization ? req.organization.name : null;
   });
 });
@@ -84,7 +85,7 @@ router.use(asyncHandler(async (req: ILocalOrgRequest, res, next) => {
 // Org membership required endpoints:
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const approvalProvider = providers.approvalProvider;
   const organization = req.organization;
   const username = req.individualContext.getGitHubIdentity().username;

--- a/routes/org/join.ts
+++ b/routes/org/join.ts
@@ -11,16 +11,14 @@ const router = express.Router();
 
 import querystring from 'querystring';
 
-import { ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 import { Team } from '../../business/team';
 import { IndividualContext } from '../../user';
 import { storeOriginalUrlAsReferrer, wrapError } from '../../utils';
-import { Organization, OrganizationMembershipState, OrganizationMembershipRole } from '../../business/organization';
-import { Operations } from '../../business/operations';
+import { Organization, OrganizationMembershipState, OrganizationMembershipRole } from '../../business';
 import QueryCache from '../../business/queryCache';
 import RequireActiveGitHubSession from '../../middleware/github/requireActiveSession';
 import { jsonError } from '../../middleware/jsonError';
-import { join } from 'lodash';
 
 router.use(function (req: ReposAppRequest, res, next) {
   const organization = req.organization;
@@ -53,8 +51,8 @@ function queryParamAsBoolean(input: string): boolean {
 }
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
-  const operations = req.app.settings.operations as Operations;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
+  const { operations } = providers;
   const organization = req.organization;
   const username = req.individualContext.getGitHubIdentity().username;
   const id = req.individualContext.getGitHubIdentity().id;
@@ -130,7 +128,7 @@ async function addMemberToOrganizationCache(queryCache: QueryCache, organization
 }
 
 router.get('/express', asyncHandler(async function (req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const organization = req.organization;
   const onboarding = queryParamAsBoolean(req.query.onboarding as string);
   const username = req.individualContext.getGitHubIdentity().username;
@@ -202,7 +200,7 @@ router.post('/', joinOrg);
 
 // /orgname/join/byClient
 router.post('/byClient', asyncHandler(async (req: ReposAppRequest, res: express.Response, next: express.NextFunction) => {
-  const { queryCache, insights } = req.app.settings.providers as IProviders;
+  const { queryCache, insights } = getProviders(req);
   const individualContext = req.individualContext as IndividualContext;
   const organization = req.organization as Organization;
   const onboarding = queryParamAsBoolean(req.query.onboarding as string);

--- a/routes/org/leave.ts
+++ b/routes/org/leave.ts
@@ -7,10 +7,9 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, UserAlertType } from '../../transitional';
+import { ReposAppRequest, UserAlertType, getProviders } from '../../transitional';
 import { wrapError } from '../../utils';
 import { Organization, OrganizationMembershipState } from '../../business/organization';
-import { Operations } from '../../business/operations';
 
 interface IOrganizationMembershipState {
   state: OrganizationMembershipState;
@@ -26,7 +25,6 @@ interface ILocalLeaveRequest extends ReposAppRequest {
 
 router.use(asyncHandler(async (req: ILocalLeaveRequest, res, next) => {
   const organization = req.organization as Organization;
-  const operations = req.app.settings.operations as Operations;
   req.orgLeave = {
     state: null,
   };
@@ -57,7 +55,7 @@ router.get('/', function (req: ILocalLeaveRequest, res) {
 
 router.post('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
   const organization = req.organization;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
   const username = req.individualContext.getGitHubIdentity().username;
   const id = req.individualContext.getGitHubIdentity().id;

--- a/routes/org/newRepoSpa.ts
+++ b/routes/org/newRepoSpa.ts
@@ -7,12 +7,12 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 import NewRepositoryLockdownSystem from '../../features/newRepositoryLockdown';
 import { Organization } from '../../business/organization';
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const individualContext = req.individualContext;
   const existingRepoId = req.query.existingrepoid as string;
   const organization = req.organization as Organization;

--- a/routes/org/profileReview.ts
+++ b/routes/org/profileReview.ts
@@ -7,8 +7,7 @@ import express from 'express';
 const router = express.Router();
 import asyncHandler from 'express-async-handler';
 
-import { ReposAppRequest } from '../../transitional';
-import { Operations } from '../../business/operations';
+import { getProviders, ReposAppRequest } from '../../transitional';
 
 interface IUserProfileWarnings {
   company?: string;
@@ -17,7 +16,7 @@ interface IUserProfileWarnings {
 
 router.get('/', asyncHandler(async function (req: ReposAppRequest, res, next) {
   const organization = req.organization;
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const config = operations.config;
   const onboarding = req.query.onboarding;
   const login = req.individualContext.getGitHubIdentity().username;

--- a/routes/org/repoAdministrativeLock.ts
+++ b/routes/org/repoAdministrativeLock.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 
 import _ from 'lodash';
 
-import { ReposAppRequest, IProviders, UserAlertType } from '../../transitional';
+import { ReposAppRequest, UserAlertType, getProviders } from '../../transitional';
 import { Repository } from '../../business/repository';
 import { RepositoryMetadataEntity } from '../../entities/repositoryMetadata/repositoryMetadata';
 import { Organization } from '../../business/organization';
@@ -42,7 +42,7 @@ router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
 }));
 
 router.post('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
   const repository = req['repository'] as Repository;
   const entity = repository.getEntity();

--- a/routes/org/repos.ts
+++ b/routes/org/repos.ts
@@ -12,7 +12,7 @@ import lowercaser from '../../middleware/lowercaser';
 
 import { Collaborator, GitHubCollaboratorAffiliationQuery, ICorporateLink, ITemporaryCommandOutput, Organization, OrganizationMember, Repository, TeamPermission } from '../../business';
 
-import { ReposAppRequest, IProviders, UserAlertType, CreateError, NoCacheNoBackground } from '../../transitional';
+import { ReposAppRequest, IProviders, UserAlertType, CreateError, NoCacheNoBackground, getProviders } from '../../transitional';
 import { RepositoryMetadataEntity } from '../../entities/repositoryMetadata/repositoryMetadata';
 import { AddRepositoryPermissionsToRequest, getContextualRepositoryPermissions, IContextualRepositoryPermissions } from '../../middleware/github/repoPermissions';
 
@@ -171,7 +171,7 @@ router.get('/:repoName/delete', asyncHandler(async function (req: ILocalRequest,
 router.post('/:repoName/delete', asyncHandler(async function (req: ILocalRequest, res, next) {
   // NOTE: this code is also duplicated for now in the client/internal/* folder
   // CONSIDER: de-duplicate
-  const { operations, repositoryMetadataProvider } = req.app.settings.providers as IProviders;
+  const { operations, repositoryMetadataProvider } = getProviders(req);
   const { organization, repository } = req;
   const lockdownSystem = new NewRepositoryLockdownSystem({ operations, organization, repository, repositoryMetadataProvider });
   await lockdownSystem.deleteLockedRepository(false /* delete for any reason */, true /* deleted by the original user instead of ops */);
@@ -187,7 +187,7 @@ export interface IRenameOutput {
 router.post('/:repoName/defaultBranch', asyncHandler(AddRepositoryPermissionsToRequest), asyncHandler(async function (req: ILocalRequest, res, next) {
   try {
     const targetBranchName = req.body.targetBranchName || 'main';
-    const providers = req.app.settings.providers as IProviders;
+    const providers = getProviders(req);
     const activeContext = (req.individualContext || req.apiContext) as IndividualContext;
     const repoPermissions = getContextualRepositoryPermissions(req);
     const repository = req.repository as Repository;
@@ -263,7 +263,7 @@ router.post('/:repoName', asyncHandler(AddRepositoryPermissionsToRequest), async
 }));
 
 router.get('/:repoName', asyncHandler(AddRepositoryPermissionsToRequest), asyncHandler(async function (req: ILocalRequest, res, next) {
-  const { linkProvider, config, graphProvider } = req.app.settings.providers as IProviders;
+  const { linkProvider, config, graphProvider } = getProviders(req);
   const repoPermissions = req.repoPermissions;
   const referer = req.headers.referer as string;
   const fromReposPage = referer && (referer.endsWith('repos') || referer.endsWith('repos/'));
@@ -465,7 +465,7 @@ router.get('/:repoName/permissions', asyncHandler(AddRepositoryPermissionsToRequ
 }));
 
 router.get('/:repoName/history', asyncHandler(async function (req: ILocalRequest, res, next) {
-  const { auditLogRecordProvider } = req.app.settings.providers as IProviders;
+  const { auditLogRecordProvider } = getProviders(req);
   const referer = req.headers.referer as string;
   const fromReposPage = referer && (referer.endsWith('repos') || referer.endsWith('repos/'));
   const organization = req.organization;

--- a/routes/org/team/approval/index.ts
+++ b/routes/org/team/approval/index.ts
@@ -7,9 +7,8 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, UserAlertType } from '../../../../transitional';
-import { wrapError } from '../../../../utils';
-import { Team } from '../../../../business/team';
+import { ReposAppRequest, IProviders, UserAlertType, getProviders } from '../../../../transitional';
+import { Team } from '../../../../business';
 import { PermissionWorkflowEngine } from '../approvals';
 import RenderHtmlMail from '../../../../lib/emailRender';
 import { IndividualContext } from '../../../../user';
@@ -61,7 +60,7 @@ router.get('/setNote/:action', function (req: ILocalRequest, res) {
 });
 
 router.post('/', asyncHandler(async (req: ILocalRequest, res, next) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const { individualContext } = req;
   const engine = req.approvalEngine as PermissionWorkflowEngine;
   let message = req.body.text as string;

--- a/routes/org/team/approvals.ts
+++ b/routes/org/team/approvals.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 
 import RouteApproval from './approval';
 
-import { IRequestTeams, ReposAppRequest } from '../../../transitional';
+import { getProviders, IRequestTeams, ReposAppRequest } from '../../../transitional';
 import { wrapError } from '../../../utils';
 import { Team } from '../../../business/team';
 import { IApprovalProvider } from '../../../entities/teamJoinApproval/approvalProvider';
@@ -111,8 +111,7 @@ interface IRequestPlusApprovalEngine extends IRequestTeams {
 router.use('/:requestid', asyncHandler(async function (req: IRequestPlusApprovalEngine, res, next) {
   const team = req.team2 as Team;
   const requestid = req.params.requestid;
-  const operations = req.app.settings.providers.operations as Operations;
-  const approvalProvider = req.app.settings.providers.approvalProvider as IApprovalProvider;
+  const { approvalProvider, operations } = getProviders(req);
   if (!approvalProvider) {
     return next(new Error('No approval provider instance available'));
   }

--- a/routes/org/team/index.ts
+++ b/routes/org/team/index.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 
 import throat from 'throat';
 
-import { ReposAppRequest, IProviders, UserAlertType } from '../../../transitional';
+import { ReposAppRequest, IProviders, UserAlertType, getProviders } from '../../../transitional';
 import { wrapError } from '../../../utils';
 import { ICorporateLink } from '../../../business/corporateLink';
 import { Team, GitHubRepositoryType, ITeamMembershipRoleState, GitHubTeamRole } from '../../../business/team';
@@ -55,7 +55,7 @@ interface ILocalRequest extends ReposAppRequest {
 }
 
 router.use(asyncHandler(async (req: ILocalRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const login = req.individualContext.getGitHubIdentity().username;
   const team2 = req.team2 as Team;
   try {
@@ -72,7 +72,7 @@ router.use(asyncHandler(async (req: ILocalRequest, res, next) => {
 }));
 
 router.use(asyncHandler(async (req: ILocalRequest, res, next) => {
-  const approvalProvider = req.app.settings.providers.approvalProvider as IApprovalProvider;
+  const { approvalProvider } = getProviders(req);
   const team2 = req.team2 as Team;
   if (!approvalProvider) {
     return next(new Error('No approval provider instance available'));
@@ -180,7 +180,7 @@ router.post('/join', asyncHandler(async (req: ILocalRequest, res, next) => {
   }
   const activeContext = req.individualContext;
   const team2 = req.team2 as Team;
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const justification = req.body.justification as string;
   const hostname = req.hostname;
   const outcome = await submitTeamJoinRequest(providers, activeContext, team2, justification, activeContext.webContext.correlationId, hostname);
@@ -447,7 +447,7 @@ enum BasicTeamViewPage {
 }
 
 async function basicTeamsView(req: ILocalRequest, display: BasicTeamViewPage) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
 
   const showManagementFeatures = parseInt(req.query['inline-management'] as string) == 1;
 
@@ -457,7 +457,7 @@ async function basicTeamsView(req: ILocalRequest, display: BasicTeamViewPage) {
   const membershipStatus = req.membershipStatus;
   const membershipState = req.membershipState;
   const team2 = req.team2 as Team;
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const organization = req.organization as Organization;
 
   const teamMaintainers = req.teamMaintainers as TeamMember[];

--- a/routes/org/team/maintainers.ts
+++ b/routes/org/team/maintainers.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, RequestTeamMemberAddType, UserAlertType, NoCacheNoBackground } from '../../../transitional';
+import { ReposAppRequest, RequestTeamMemberAddType, UserAlertType, NoCacheNoBackground, getProviders } from '../../../transitional';
 import { Team } from '../../../business/team';
 import { TeamMember } from '../../../business/teamMember';
 
@@ -70,7 +70,7 @@ router.use('/add', MiddlewareTeamAdminRequired, (req: ILocalRequest, res, next) 
 });
 
 router.post('/add', MiddlewareTeamAdminRequired, asyncHandler(async function (req: ILocalRequest, res, next) {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const login = operations.validateGitHubLogin(req.body.username);
   const team2 = req.team2 as Team;
   await team2.addMaintainer(login);

--- a/routes/org/team/members.ts
+++ b/routes/org/team/members.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, RequestTeamMemberAddType, UserAlertType } from '../../../transitional';
+import { ReposAppRequest, RequestTeamMemberAddType, UserAlertType, getProviders } from '../../../transitional';
 import { Team } from '../../../business/team';
 import { TeamMember } from '../../../business/teamMember';
 
@@ -66,7 +66,7 @@ router.use('/add', MiddlewareTeamAdminRequired, (req: ILocalTeamRequest, res, ne
 }, RoutePeopleSearch);
 
 router.post('/remove', MiddlewareTeamAdminRequired, asyncHandler(async (req: ILocalTeamRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const username = operations.validateGitHubLogin(req.body.username);
   const team2 = req.team2 as Team;
   await team2.removeMembership(username);
@@ -76,7 +76,7 @@ router.post('/remove', MiddlewareTeamAdminRequired, asyncHandler(async (req: ILo
 }));
 
 router.post('/add', MiddlewareTeamAdminRequired, asyncHandler(async (req: ILocalTeamRequest, res, next) => {
-  const { operations } = req.app.settings.providers as IProviders;
+  const { operations } = getProviders(req);
   const username = operations.validateGitHubLogin(req.body.username);
   const organization = req.organization;
   const team2 = req.team2;

--- a/routes/orgs.ts
+++ b/routes/orgs.ts
@@ -10,7 +10,7 @@ const router = express.Router();
 import querystring from 'querystring';
 import { injectReactClient, TryFallbackToBlob } from '../middleware';
 
-import { hasStaticReactClientApp, IReposRequestWithOrganization } from '../transitional';
+import { getProviders, hasStaticReactClientApp, IReposRequestWithOrganization } from '../transitional';
 import { wrapError } from '../utils';
 
 import orgRoute from './org/';
@@ -29,7 +29,7 @@ async function forwardToOrganizationRoutes (req: IReposRequestWithOrganization, 
   // This middleware contains both the original GitHub operations types
   // as well as the newer implementation. In time this will peel apart.
   const orgName = req.params.orgName;
-  const operations = req.app.settings.operations;
+  const { operations } = getProviders(req);
   try {
     const organization = operations.getOrganization(orgName);
     req.organization = organization;

--- a/routes/people.ts
+++ b/routes/people.ts
@@ -6,7 +6,7 @@
 import express from 'express';
 const router = express.Router();
 
-import { ReposAppRequest } from '../transitional';
+import { getProviders, ReposAppRequest } from '../transitional';
 
 import RoutePeopleSearch from './peopleSearch';
 import MiddlewareSystemWidePermissions from '../middleware/github/systemWidePermissions';
@@ -22,10 +22,11 @@ router.use(function (req: ReposAppRequest, res, next) {
 
 // Campaign-related redirect to take the user to GitHub
 router.get('/github/:login', (req: ReposAppRequest, res, next) => {
-  if (!req.app.settings.providers || !req.app.settings.providers.campaign) {
+  const providers = getProviders(req);
+  if (!providers || !providers.campaign) {
     return next();
   }
-  return req.app.settings.providers.campaign.redirectGitHubMiddleware(req, res, next, () => {
+  return providers.campaign.redirectGitHubMiddleware(req, res, next, () => {
     const login = req.params.login;
     return login ? login : null;
   });

--- a/routes/peopleSearch.ts
+++ b/routes/peopleSearch.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { RequestWithSystemwidePermissions, RequestTeamMemberAddType } from '../transitional';
+import { RequestWithSystemwidePermissions, RequestTeamMemberAddType, getProviders } from '../transitional';
 
 import { ensureAllLinksInMemory, getAllLinksFromRequest } from '../middleware/business/allLinks';
 
@@ -65,7 +65,7 @@ async function getPeopleAcrossOrganizations(operations: Operations, options, tea
 
 router.get('/', lowercaser(['sort']), asyncHandler(async (req: IPeopleSearchRequest, res, next) => {
   const linksFromMiddleware = getAllLinksFromRequest(req);
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const org = req.organization ? req.organization.name : null;
   const orgId = req.organization ? (req.organization as Organization).id : null;
   const isPortalSudoer = req.systemWidePermissions && req.systemWidePermissions.allowAdministration === true;

--- a/routes/placeholders.ts
+++ b/routes/placeholders.ts
@@ -6,21 +6,27 @@
 import express from 'express';
 const router = express.Router();
 
+import { getProviders, ReposAppRequest } from '../transitional';
+
 // These are Microsoft-specific, we'll remove these eventually.
+// TODO: remove from open source version since not helpful having random routes in place
 
-router.use('/data', (req, res) => {
-  const exploreUrl = req.app.settings.runtimeConfig.urls.explore;
-  res.redirect(`${exploreUrl}resources/insights`);
+router.use('/data', (req: ReposAppRequest, res) => {
+  const { config } = getProviders(req);
+  const exploreUrl = config?.urls?.explore;
+  res.redirect(exploreUrl ? `${exploreUrl}resources/insights` : '/');
 });
 
-router.use('/use', (req, res) => {
-  const exploreUrl = req.app.settings.runtimeConfig.urls.explore;
-  res.redirect(`${exploreUrl}resources/use`);
+router.use('/use', (req: ReposAppRequest, res) => {
+  const { config } = getProviders(req);
+  const exploreUrl = config?.urls?.explore;
+  res.redirect(exploreUrl ? `${exploreUrl}resources/use` : '/');
 });
 
-router.use('/release', (req, res) => {
-  const exploreUrl = req.app.settings.runtimeConfig.urls.explore;
-  res.redirect(`${exploreUrl}resources/release`);
+router.use('/release', (req: ReposAppRequest, res) => {
+  const { config } = getProviders(req);
+  const exploreUrl = config?.urls?.explore;
+  res.redirect(exploreUrl ? `${exploreUrl}resources/release` : '/');
 });
 
 export default router;

--- a/routes/reposPager.ts
+++ b/routes/reposPager.ts
@@ -7,7 +7,7 @@ import asyncHandler from 'express-async-handler';
 import express from 'express';
 import _ from 'lodash';
 
-import { IReposAppWithTeam, IProviders } from '../transitional';
+import { IReposAppWithTeam, getProviders } from '../transitional';
 import { Operations } from '../business/operations';
 import { Repository } from '../business/repository';
 import { Team, GitHubRepositoryType } from '../business/team';
@@ -66,7 +66,7 @@ async function getReposAndOptionalTeamPermissions(organizationId: number, operat
 }
 
 export default asyncHandler(async function (req: IReposAppWithTeam, res: express.Response, next: express.NextFunction) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const operations = providers.operations;
   const queryCache = providers.queryCache;
   const individualContext = req.individualContext;

--- a/routes/settings/authorizations.ts
+++ b/routes/settings/authorizations.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, ICallback } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 import { ICorporateLink } from '../../business/corporateLink';
 import { Operations } from '../../business/operations';
 
@@ -54,7 +54,7 @@ function createValidator(operations: Operations, link: ICorporateLink, token: st
 router.use((req: IRequestWithAuthorizations, res, next) => {
   // This is a lightweight, temporary implementation of authorization management to help clear
   // stored session tokens for apps like GitHub, VSTS, etc.
-  const operations = req.app.settings.providers.operations as Operations;
+  const { operations } = getProviders(req);
   const link = req.individualContext.link;
   const authorizations = [];
   if (req.individualContext.webContext.tokens.gitHubReadToken) {

--- a/routes/settings/campaigns.ts
+++ b/routes/settings/campaigns.ts
@@ -7,10 +7,10 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, CreateError, UserAlertType } from '../../transitional';
+import { ReposAppRequest, CreateError, UserAlertType, getProviders } from '../../transitional';
 
 router.use('/:campaignGroupId', (req:  ReposAppRequest, res: any, next) => {
-  const { config } = req.app.settings.providers as IProviders;
+  const { config } = getProviders(req);
   const knownCampaignGroups = (config?.campaigns?.groups || '').toLowerCase().split(',');
   req.params.campaignGroupId = req.params.campaignGroupId.toLowerCase();
   const { campaignGroupId } = req.params;
@@ -29,7 +29,7 @@ router.get('/:campaignGroupId/subscribe', asyncHandler(async (req: ReposAppReque
 }));
 
 router.get('/:campaignGroupId', asyncHandler(async (req: ReposAppRequest, res: any, next) => {
-  const { campaignStateProvider } = req.app.settings.providers as IProviders;
+  const { campaignStateProvider } = getProviders(req);
   if (!campaignStateProvider) {
     return next(new Error('This app is not configured for campaign management'));
   }
@@ -46,7 +46,7 @@ router.get('/:campaignGroupId', asyncHandler(async (req: ReposAppRequest, res: a
 }));
 
 async function modifySubscription(isUnsubscribing: boolean, req: ReposAppRequest, res: any, next: any) {
-  const { campaignStateProvider } = req.app.settings.providers as IProviders;
+  const { campaignStateProvider } = getProviders(req);
   if (!campaignStateProvider) {
     return next(new Error('This app is not configured for campaign management'));
   }

--- a/routes/settings/contributionData.ts
+++ b/routes/settings/contributionData.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders, UserAlertType, ErrorHelper } from '../../transitional';
+import { ReposAppRequest, UserAlertType, ErrorHelper, getProviders } from '../../transitional';
 import { UserSettings } from '../../entities/userSettings';
 
 export interface IRequestWithUserSettings extends ReposAppRequest {
@@ -16,7 +16,7 @@ export interface IRequestWithUserSettings extends ReposAppRequest {
 
 async function getSettings(req: IRequestWithUserSettings, res, next) {
   const corporateId = req.individualContext.corporateIdentity.id;
-  const { userSettingsProvider } = req.app.settings.providers as IProviders;
+  const { userSettingsProvider } = getProviders(req);
   if (!req.userSettings) {
     let settings: UserSettings = null;
     try {
@@ -61,7 +61,7 @@ router.post('/', asyncHandler(async function (req: IRequestWithUserSettings, res
   if (!changed) {
     return next(new Error('No change to sharing setting.'));
   }
-  const { userSettingsProvider } = req.app.settings.providers as IProviders;
+  const { userSettingsProvider } = getProviders(req);
   await userSettingsProvider.updateUserSettings(req.userSettings);
   const message = isOptIn ? 'You have opted in to sharing of contribution data.' : 'You have opted out of sharing contribution data.';
   const title = isOptIn ? 'Opt-in saved' : 'Opt-out';

--- a/routes/settings/digestReports.ts
+++ b/routes/settings/digestReports.ts
@@ -6,7 +6,7 @@
 import express from 'express';
 const router = express.Router();
 
-import { RequestWithSystemwidePermissions } from '../../transitional';
+import { getProviders, RequestWithSystemwidePermissions } from '../../transitional';
 import { IndividualContext } from '../../user';
 
 // import { buildConsolidatedMap as buildRecipientMap } from '../../jobs/reports/consolidated';
@@ -35,7 +35,7 @@ router.use((req: IRequestWithDigestReports, res, next) => {
   // when the Redis server is the same for both reports and the
   // app
 
-  const providers = req.app.settings.providers;
+  const providers = getProviders(req);
   const config = providers.config;
 
   const reportConfig = config && config.github && config.github.jobs ? config.github.jobs.reports : {};

--- a/routes/settings/index.ts
+++ b/routes/settings/index.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 import { AddLinkToRequest } from '../../middleware/links/';
 
 import approvalsRoute from './approvals';
@@ -21,7 +21,7 @@ import campaignsRoute from './campaigns';
 router.use(asyncHandler(AddLinkToRequest));
 
 router.get('/', asyncHandler( async (req: ReposAppRequest, res) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const link = req.individualContext.link;
   let legalContactInformation = null;
   try {

--- a/routes/settings/personalAccessTokens.ts
+++ b/routes/settings/personalAccessTokens.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
-import { IResponseForSettingsPersonalAccessTokens, ReposAppRequest, IProviders } from '../../transitional';
+import { ReposAppRequest, getProviders } from '../../transitional';
 import { PersonalAccessToken } from '../../entities/token/token';
 
 interface IPersonalAccessTokenForDisplay {
@@ -46,7 +46,7 @@ function translateTableToEntities(personalAccessTokens: PersonalAccessToken[]): 
 }
 
 function getPersonalAccessTokens(req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const tokenProvider = providers.tokenProvider;
   const corporateId = req.individualContext.corporateIdentity.id;
   tokenProvider.queryTokensForCorporateId(corporateId).then(tokens => {
@@ -75,7 +75,7 @@ router.use(getPersonalAccessTokens);
 router.get('/', view);
 
 function createToken(req: ReposAppRequest, res, next) {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const tokenProvider = providers.tokenProvider;
   const insights = req.insights;
   const description = req.body.description;
@@ -126,7 +126,7 @@ router.post('/create', createToken);
 router.post('/extension', createToken);
 
 router.post('/delete', asyncHandler(async (req: IRequestForSettingsPersonalAccessTokens, res, next) => {
-  const providers = req.app.settings.providers as IProviders;
+  const providers = getProviders(req);
   const tokenProvider = providers.tokenProvider;
   const revokeAll = req.body.revokeAll === '1';
   const revokeIdentifier = req.body.revoke;

--- a/routes/teamsPager.ts
+++ b/routes/teamsPager.ts
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
 import express from 'express';
 
-import { ReposAppRequest } from '../transitional';
+import { getProviders, ReposAppRequest } from '../transitional';
 import { Operations, ICrossOrganizationMembershipByOrganization } from '../business/operations';
 import { Team } from '../business/team';
 import { UserContext } from '../user/aggregate';
@@ -73,7 +73,7 @@ function reduceTeams(collections, property, map) {
 }
 
 export default asyncHandler(async function(req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
-  const operations = req.app.settings.operations as Operations;
+  const { operations } = getProviders(req);
   const isCrossOrg = req.teamsPagerMode === 'orgs';
   const aggregations = req.individualContext.aggregations;
   const orgName = isCrossOrg ? null : req.organization.name.toLowerCase();

--- a/routes/thanks.ts
+++ b/routes/thanks.ts
@@ -5,6 +5,7 @@
 
 //import * as thisPackage from '../package.json';
 import thisPackage = require('../package.json');
+import { getProviders, ReposAppRequest } from '../transitional';
 // var thisPackage = require('/package.json');
 
 var express = require('express');
@@ -32,9 +33,10 @@ function getPackageInfo(config) {
   return cachedPackageInformation;
 }
 
-router.get('/', function (req, res) {
-  var config = req.app.settings.runtimeConfig.obfuscatedConfig;
-  var components = getPackageInfo(config);
+router.get('/', function (req: ReposAppRequest, res) {
+  const { config: completeConfig} = getProviders(req);
+  const config = completeConfig.obfuscatedConfig;
+  const components = getPackageInfo(config);
   res.render('thanks', {
     config: config,
     components: components,

--- a/routes/undo.ts
+++ b/routes/undo.ts
@@ -8,7 +8,7 @@ import asyncHandler from 'express-async-handler';
 const router = express.Router();
 
 import { Operations } from '../business/operations';
-import { ReposAppRequest, ErrorHelper, UserAlertType } from '../transitional';
+import { ReposAppRequest, ErrorHelper, UserAlertType, getProviders } from '../transitional';
 import { AuditLogRecord } from '../entities/auditLogRecord/auditLogRecord';
 import { daysInMilliseconds } from '../utils';
 import { AuditEvents } from '../entities/auditLogRecord';
@@ -243,7 +243,7 @@ async function undoTeamAdminRepoPermissionAsync(operations: Operations, entry: I
 }
 
 router.use(asyncHandler(async function (req: IHaveUndoCandiates, res, next) {
-  const operations = req.app.settings.providers.operations as Operations;
+  const { operations } = getProviders(req);
   if (!operations.allowUndoSystem) {
     res.status(404);
     return next(new Error('This feature is unavailable in this application instance'));
@@ -269,7 +269,7 @@ router.use(asyncHandler(async function (req: IHaveUndoCandiates, res, next) {
 }));
 
 router.post('/', asyncHandler(async (req: IHaveUndoCandiates, res, next) => {
-  const operations = req.app.settings.providers.operations as Operations;
+  const { operations } = getProviders(req);
   const insights = operations.insights;
   const link = req.individualContext.link;
   const githubId = req.individualContext.getGitHubIdentity().id;
@@ -326,7 +326,7 @@ router.post('/', asyncHandler(async (req: IHaveUndoCandiates, res, next) => {
 }));
 
 router.get('/', asyncHandler(async (req: IHaveUndoCandiates, res, next) => {
-  const operations = req.app.settings.providers.operations as Operations;
+  const { operations } = getProviders(req);
   const insights = operations.insights;
   insights?.trackMetric({ name: 'UndoPageViews', value: 1 });
   return req.individualContext.webContext.render({

--- a/transitional.ts
+++ b/transitional.ts
@@ -299,6 +299,10 @@ export interface ReposAppRequest extends Request {
   oauthAccessToken: AccessToken;
 }
 
+export function getProviders(req: ReposAppRequest) {
+  return req.app.settings.providers as IProviders;
+}
+
 export interface IReposAppResponse extends Response {
 }
 
@@ -556,6 +560,7 @@ interface IAppSessionProperties extends Session {
   passport: any;
   id: string;
   alerts?: IUserAlert[];
+  referer: string;
 }
 
 export interface IAppSession extends IAppSessionProperties {}

--- a/user/index.ts
+++ b/user/index.ts
@@ -7,10 +7,9 @@ import { ReposAppRequest, IReposAppResponse, UserAlertType, IDictionary, IProvid
 
 import { ICorporateLink } from '../business/corporateLink';
 
-import { addBreadcrumb, wrapError } from '../utils';
-import { Operations } from "../business/operations";
-import { GitHubTeamRole } from "../business/team";
-import { UserContext } from "./aggregate";
+import { addBreadcrumb } from '../utils';
+import { Operations } from '../business/operations';
+import { UserContext } from './aggregate';
 
 import pugLoad from 'pug-load';
 import fs from 'fs';


### PR DESCRIPTION
For improved type safety, this uses a function to return the
IProviders instance from the Express app, replacing all instances
of using req.app.settings.providers as IProviders, etc.

This may also make everything slightly more testable, eventually.