### PR TITLE
allow custom pageSize for people search

### DIFF
--- a/routes/peopleSearch.ts
+++ b/routes/peopleSearch.ts
@@ -77,6 +77,7 @@ router.get('/', lowercaser(['sort']), asyncHandler(async (req: IPeopleSearchRequ
   }
   const { crossOrganizationMembers, organizationMembers, teamMembers } = org ? await getPeopleForOrganization(operations, org, options, team2) : await getPeopleAcrossOrganizations(operations, options, team2);
   const page = req.query.page_number ? Number(req.query.page_number) : 1;
+  const pageSize = req.query.pageSize ? Number(req.query.pageSize) : undefined;
   let phrase = req.query.q as string;
   let type = req.query.type as string;
   const validTypes = new Set([
@@ -124,6 +125,7 @@ router.get('/', lowercaser(['sort']), asyncHandler(async (req: IPeopleSearchRequ
     links: linksFromMiddleware,
     providers: operations.providers,
     orgId,
+    pageSize,
     organizationMembers,
     crossOrganizationMembers,
     isOrganizationScoped: !!org, // Whether this view is specific to an org or not
@@ -149,6 +151,7 @@ router.get('/', lowercaser(['sort']), asyncHandler(async (req: IPeopleSearchRequ
         phrase,
         twoFactor,
         type,
+        pageSize,
       },
       organization: req.organization || undefined,
       lightupSudoerLink: type === 'former' && isPortalSudoer,

--- a/views/people/index.pug
+++ b/views/people/index.pug
@@ -154,12 +154,12 @@ block content
           nav(style='margin-bottom:48px')
             ul.pager
               li.previous(class=(previous_possible ? '' : 'invisible'))
-                a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
+                a(href='?page_number=' + (search.page-1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : '') + (query.pageSize ? '&pageSize=' + query.pageSize : ''))
                   span(aria-hidden="true") &larr; Previous
               li
                 | #{search.pageFirstItem.toLocaleString()} - #{search.pageLastItem.toLocaleString()} of #{search.totalItems.toLocaleString()} #{itemType}
               li.next(class=(next_possible ? '' : 'invisible'))
-                a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : ''))
+                a(href='?page_number=' + (search.page+1) + (query.twoFactor ? '&twoFactor=' + query.twoFactor : '') + (search.sort ? '&sort=' + search.sort : '') + (query.type ? '&type=' + query.type : '') + (query.phrase ? '&q=' + query.phrase : '') + (query.pageSize ? '&pageSize=' + query.pageSize : ''))
                   span(aria-hidden="true") Next &rarr;
 
           .row.vertical-pad-bottom


### PR DESCRIPTION
This PR allows to specify an additional query parameter in the people search, this is especially handy when working with large organizations and teams to get see everyone on a single page. 

The PR only exposes it as a query parameter and doesn't provide a UI element for picking the page size, mainly to allow only power users to leverage it (e.g. to send mails to everyone on the page and with a large pageSize this is easier than copying several pages together).