### PR TITLE
Express import destructuring

### DIFF
--- a/api/client/banner.ts
+++ b/api/client/banner.ts
@@ -3,13 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import { ReposAppRequest } from '../../interfaces';
 
 import { jsonError } from '../../middleware';
 import { getProviders } from '../../transitional';
 
-const router = express.Router();
+const router: Router = Router();
 
 // TODO: move to modern w/administration experience, optionally
 

--- a/api/client/banner.ts
+++ b/api/client/banner.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import { ReposAppRequest } from '../../interfaces';
 
 import { jsonError } from '../../middleware';

--- a/api/client/context/approvals.ts
+++ b/api/client/context/approvals.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Team, Organization } from '../../../business';

--- a/api/client/context/approvals.ts
+++ b/api/client/context/approvals.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Team, Organization } from '../../../business';
@@ -14,7 +14,7 @@ import { ApprovalPair, Approvals_getTeamMaintainerApprovals, Approvals_getUserRe
 import { getProviders } from '../../../transitional';
 import { IndividualContext } from '../../../user';
 
-const router = express.Router();
+const router: Router = Router();
 
 const approvalPairToJson = (pair: ApprovalPair) => {
   return {

--- a/api/client/context/index.ts
+++ b/api/client/context/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Organization } from '../../../business';

--- a/api/client/context/index.ts
+++ b/api/client/context/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Organization } from '../../../business';
@@ -20,7 +20,7 @@ import RouteOrgs from './orgs';
 import RouteRepos from './repos';
 import RouteTeams from './teams';
 
-const router = express.Router();
+const router: Router = Router();
 
 const deployment = getCompanySpecificDeployment();
 deployment?.routes?.api?.context?.index && deployment?.routes?.api?.context?.index(router);

--- a/api/client/context/organization/index.ts
+++ b/api/client/context/organization/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Organization, Team } from '../../../../business';
 import { ReposAppRequest, OrganizationMembershipRole, TeamJsonFormat, GitHubTeamRole } from '../../../../interfaces';

--- a/api/client/context/organization/index.ts
+++ b/api/client/context/organization/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Organization, Team } from '../../../../business';
 import { ReposAppRequest, OrganizationMembershipRole, TeamJsonFormat, GitHubTeamRole } from '../../../../interfaces';
@@ -14,7 +14,7 @@ import { IndividualContext } from '../../../../user';
 import RouteRepos from './repos';
 import RouteTeams from './teams';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { organization } = req;
@@ -78,7 +78,7 @@ router.delete('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
       message: `Your ${login} account has been removed from ${organization.name}.`,
     });
   } catch (error) {
-    console.warn(error);    
+    console.warn(error);
     return next(jsonError(error, 400));
   }
 }));

--- a/api/client/context/organization/repo.ts
+++ b/api/client/context/organization/repo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { AddRepositoryPermissionsToRequest, getContextualRepositoryPermissions } from '../../../../middleware/github/repoPermissions';

--- a/api/client/context/organization/repo.ts
+++ b/api/client/context/organization/repo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { AddRepositoryPermissionsToRequest, getContextualRepositoryPermissions } from '../../../../middleware/github/repoPermissions';
@@ -11,7 +11,7 @@ import { jsonError } from '../../../../middleware';
 import getCompanySpecificDeployment from '../../../../middleware/companySpecificDeployment';
 import { ReposAppRequest } from '../../../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/permissions', AddRepositoryPermissionsToRequest, asyncHandler(async (req: ReposAppRequest, res, next) => {
   const permissions = getContextualRepositoryPermissions(req);

--- a/api/client/context/organization/repos.ts
+++ b/api/client/context/organization/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Repository } from '../../../../business';
 import { jsonError } from '../../../../middleware';

--- a/api/client/context/organization/repos.ts
+++ b/api/client/context/organization/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Repository } from '../../../../business';
 import { jsonError } from '../../../../middleware';
@@ -15,7 +15,7 @@ import { createRepositoryFromClient } from '../../newOrgRepo';
 
 import RouteContextualRepo from './repo';
 
-const router = express.Router();
+const router: Router = Router();
 
 async function validateActiveMembership(req: ReposAppRequest, res, next) {
   const { organization } = req;

--- a/api/client/context/organization/team.ts
+++ b/api/client/context/organization/team.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { TeamJoinApprovalEntity } from '../../../../entities/teamJoinApproval/teamJoinApproval';
@@ -16,7 +16,7 @@ import { PermissionWorkflowEngine } from '../../../../routes/org/team/approvals'
 import { getProviders } from '../../../../transitional';
 import { IndividualContext } from '../../../../user';
 
-const router = express.Router();
+const router: Router = Router();
 
 interface ITeamRequestJsonResponse {
   request?: TeamJoinApprovalEntity;
@@ -27,7 +27,7 @@ interface ITeamApprovalsJsonResponse {
   approvals?: TeamJoinApprovalEntity[];
 }
 
-router.get('/permissions', 
+router.get('/permissions',
   asyncHandler(AddTeamPermissionsToRequest),
   asyncHandler(AddTeamMembershipToRequest),
   asyncHandler(async (req: ReposAppRequest, res, next) => {
@@ -74,7 +74,7 @@ router.post('/join',
       if (request) {
         return res.json({ error: 'You already have a pending team join request' });
       }
-      // 
+      //
       const justification = (req.body.justification || '') as string;
       const hostname = req.hostname;
       const correlationId = req.correlationId;
@@ -156,7 +156,7 @@ router.get('/join/approvals/:approvalId',
   return res.json({ approval: request });
 }));
 
-router.get('/join/approvals', 
+router.get('/join/approvals',
   asyncHandler(AddTeamPermissionsToRequest),
   asyncHandler(async (req: ReposAppRequest, res, next) => {
     const { approvalProvider } = getProviders(req);

--- a/api/client/context/organization/team.ts
+++ b/api/client/context/organization/team.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { TeamJoinApprovalEntity } from '../../../../entities/teamJoinApproval/teamJoinApproval';

--- a/api/client/context/organization/teams.ts
+++ b/api/client/context/organization/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Team } from '../../../../business';
 import { jsonError } from '../../../../middleware';
@@ -12,7 +12,7 @@ import { ReposAppRequest } from '../../../../interfaces';
 
 import RouteTeam from './team';
 
-const router = express.Router();
+const router: Router = Router();
 
 // CONSIDER: list their teams router.get('/ ')
 

--- a/api/client/context/organization/teams.ts
+++ b/api/client/context/organization/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { Team } from '../../../../business';
 import { jsonError } from '../../../../middleware';

--- a/api/client/index.ts
+++ b/api/client/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { apiContextMiddleware, AddLinkToRequest, requireAccessTokenClient, setIdentity, jsonError } from '../../middleware';
@@ -23,7 +23,7 @@ import RouteCrossOrganizationRepos from './repos';
 import RouteCrossOrganizationTeams from './teams';
 import { ReposAppRequest } from '../../interfaces';
 
-const router = express.Router();
+const router: Router = Router()
 
 router.use((req: ReposAppRequest, res, next) => {
   const { config } = getProviders(req);

--- a/api/client/index.ts
+++ b/api/client/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { apiContextMiddleware, AddLinkToRequest, requireAccessTokenClient, setIdentity, jsonError } from '../../middleware';

--- a/api/client/linking.ts
+++ b/api/client/linking.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { IndividualContext } from '../../user';
@@ -13,7 +13,7 @@ import { unlinkInteractive } from '../../routes/unlink';
 import { interactiveLinkUser } from '../../routes/link';
 import { ReposAppRequest } from '../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 async function validateLinkOk(req: ReposAppRequest, res, next) {
   const activeContext = (req.individualContext || req.apiContext) as IndividualContext;

--- a/api/client/linking.ts
+++ b/api/client/linking.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { IndividualContext } from '../../user';

--- a/api/client/newOrgRepo.ts
+++ b/api/client/newOrgRepo.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import _ from 'lodash';
 
@@ -240,7 +240,7 @@ export async function createRepositoryFromClient(req: ILocalApiRequest, res, nex
   translateValue(body, 'legalEntity', 'ms.entity');
   translateValue(body, 'projectType', 'ms.project-type');
   // Team permissions
-  let sufficientTeamsOk = false;  
+  let sufficientTeamsOk = false;
   if (customizedNewRepositoryLogic?.sufficientTeamsConfigured) {
     sufficientTeamsOk = customizedNewRepositoryLogic.sufficientTeamsConfigured(customContext, body);
   }
@@ -274,7 +274,7 @@ export async function createRepositoryFromClient(req: ILocalApiRequest, res, nex
       }
     } catch (graphError) {
       insights?.trackException({ exception: graphError });
-      console.warn(`Retrieving user mail address error: ${graphError}`);  
+      console.warn(`Retrieving user mail address error: ${graphError}`);
     }
   }
   if (!body['ms.notify']) {

--- a/api/client/newOrgRepo.ts
+++ b/api/client/newOrgRepo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/api/client/newRepo.ts
+++ b/api/client/newRepo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { getProviders } from '../../transitional';

--- a/api/client/newRepo.ts
+++ b/api/client/newRepo.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { jsonError } from '../../middleware/jsonError';

--- a/api/client/organization/index.ts
+++ b/api/client/organization/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import RouteRepos from './repos';
@@ -14,7 +14,7 @@ import { ReposAppRequest } from '../../../interfaces';
 import { jsonError } from '../../../middleware';
 import getCompanySpecificDeployment from '../../../middleware/companySpecificDeployment';
 
-const router = express.Router();
+const router: Router = Router();
 
 const deployment = getCompanySpecificDeployment();
 deployment?.routes?.api?.organization?.index && deployment?.routes?.api?.organization?.index(router);

--- a/api/client/organization/index.ts
+++ b/api/client/organization/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import RouteRepos from './repos';

--- a/api/client/organization/newRepoMetadata.ts
+++ b/api/client/organization/newRepoMetadata.ts
@@ -3,13 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware/jsonError';
 import { ReposAppRequest } from '../../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { organization } = req;
@@ -21,7 +21,7 @@ router.get('/byProjectReleaseType', asyncHandler(async (req: ReposAppRequest, re
   const { organization } = req;
   const options = {
     projectType: req.query.projectType,
-  };  
+  };
   const metadata = organization.getRepositoryCreateMetadata(options);
   res.json(metadata);
 }));

--- a/api/client/organization/newRepoMetadata.ts
+++ b/api/client/organization/newRepoMetadata.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware/jsonError';

--- a/api/client/organization/people.ts
+++ b/api/client/organization/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';
@@ -13,7 +13,7 @@ import JsonPager from '../jsonPager';
 import { OrganizationMember, TeamMember, Operations, Team, Organization, MemberSearch, corporateLinkToJson } from '../../../business';
 import { NoCacheNoBackground, ReposAppRequest } from '../../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 // BAD PRACTICE: leaky local cache
 // CONSIDER: use a better approach

--- a/api/client/organization/people.ts
+++ b/api/client/organization/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';

--- a/api/client/organization/repo.ts
+++ b/api/client/organization/repo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';
@@ -22,7 +22,7 @@ type RequestWithRepo = ReposAppRequest & {
   repository: Repository;
 };
 
-const router = express.Router();
+const router: Router = Router();
 
 const deployment = getCompanySpecificDeployment();
 deployment?.routes?.api?.organization?.repo && deployment?.routes?.api?.organization?.repo(router);

--- a/api/client/organization/repo.ts
+++ b/api/client/organization/repo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';

--- a/api/client/organization/repoPermissions.ts
+++ b/api/client/organization/repoPermissions.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware/jsonError';
@@ -15,7 +15,7 @@ type RequestWithRepo = ReposAppRequest & {
   repository: Repository;
 };
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: RequestWithRepo, res, next) => {
   const { repository, organization } = req;

--- a/api/client/organization/repoPermissions.ts
+++ b/api/client/organization/repoPermissions.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware/jsonError';

--- a/api/client/organization/repos.ts
+++ b/api/client/organization/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';

--- a/api/client/organization/repos.ts
+++ b/api/client/organization/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../../middleware';
@@ -14,7 +14,7 @@ import RouteRepo from './repo';
 import JsonPager from '../jsonPager';
 import { ReposAppRequest, IProviders } from '../../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { organization } = req;

--- a/api/client/organization/team.ts
+++ b/api/client/organization/team.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { getContextualTeam } from '../../../middleware/github/teamPermissions';

--- a/api/client/organization/team.ts
+++ b/api/client/organization/team.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { getContextualTeam } from '../../../middleware/github/teamPermissions';
@@ -17,7 +17,7 @@ import { equivalentLegacyPeopleSearch } from './people';
 import { TeamRepositoryPermission, OrganizationMember, corporateLinkToJson } from '../../../business';
 import { ReposAppRequest, TeamJsonFormat, NoCacheNoBackground, ICorporateLink } from '../../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const team = getContextualTeam(req);

--- a/api/client/organization/teams.ts
+++ b/api/client/organization/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Organization } from '../../../business/organization';
@@ -16,7 +16,7 @@ import LeakyLocalCache from '../leakyLocalCache';
 import RouteTeam from './team';
 import { Team } from '../../../business';
 
-const router = express.Router();
+const router: Router = Router();
 
 // BAD PRACTICE: leaky local cache
 // CONSIDER: use a better approach

--- a/api/client/organization/teams.ts
+++ b/api/client/organization/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Organization } from '../../../business/organization';

--- a/api/client/organizations.ts
+++ b/api/client/organizations.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../middleware';
@@ -12,7 +12,7 @@ import { ReposAppRequest } from '../../interfaces';
 
 import RouteOrganization from './organization';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const { operations } = getProviders(req);

--- a/api/client/organizations.ts
+++ b/api/client/organizations.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../middleware';

--- a/api/client/people.ts
+++ b/api/client/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { corporateLinkToJson } from '../../business';

--- a/api/client/people.ts
+++ b/api/client/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { corporateLinkToJson } from '../../business';
@@ -15,7 +15,7 @@ import getCompanySpecificDeployment from '../../middleware/companySpecificDeploy
 import RouteGetPerson from './person';
 import { equivalentLegacyPeopleSearch } from './peopleSearch';
 
-const router = express.Router();
+const router: Router = Router();
 
 const deployment = getCompanySpecificDeployment();
 deployment?.routes?.api?.people && deployment.routes.api.people(router);

--- a/api/client/repos.ts
+++ b/api/client/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Repository } from '../../business';
@@ -13,7 +13,7 @@ import { getProviders } from '../../transitional';
 import JsonPager from './jsonPager';
 import { RepositorySearchSortOrder, searchRepos } from './organization/repos';
 
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', asyncHandler(async (req: ReposAppRequest, res, next) => {
   const providers = getProviders(req);

--- a/api/client/repos.ts
+++ b/api/client/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Repository } from '../../business';

--- a/api/client/session.ts
+++ b/api/client/session.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 
 import { jsonError } from '../../middleware/jsonError';
 import { IAppSession, ReposAppRequest } from '../../interfaces';

--- a/api/client/session.ts
+++ b/api/client/session.ts
@@ -3,12 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 
 import { jsonError } from '../../middleware/jsonError';
 import { IAppSession, ReposAppRequest } from '../../interfaces';
 
-const router = express.Router();
+const router: Router = Router();
 
 // This route is /api/client/signout*
 

--- a/api/client/teams.ts
+++ b/api/client/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Operations, Team } from '../../business';

--- a/api/client/teams.ts
+++ b/api/client/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Operations, Team } from '../../business';
@@ -12,7 +12,7 @@ import { jsonError } from '../../middleware';
 import { getProviders } from '../../transitional';
 import JsonPager from './jsonPager';
 
-const router = express.Router();
+const router: Router = Router();
 
 async function getCrossOrganizationTeams(operations: Operations): Promise<Team[]> {
   const options = {

--- a/api/extension.ts
+++ b/api/extension.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import express, { Router, Response } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 
@@ -19,7 +19,7 @@ import { PersonalAccessToken } from '../entities/token/token';
 
 const thisApiScopeName = 'extension';
 
-interface IExtensionResponse extends express.Response {
+interface IExtensionResponse extends Response {
   localKey?: any;
 }
 

--- a/api/extension.ts
+++ b/api/extension.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../transitional';
 import { setIdentity } from '../middleware/business/authentication';

--- a/api/extension.ts
+++ b/api/extension.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router, Response } from 'express';
+import { Router, Response } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import cors from 'cors';
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/api/people/index.ts
+++ b/api/people/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 
 import { json404 } from '../../middleware/jsonError';
 

--- a/api/people/index.ts
+++ b/api/people/index.ts
@@ -3,11 +3,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 
 import { json404 } from '../../middleware/jsonError';
 
-const router = express.Router();
+const router: Router = Router();
 
 import LinksRoute from './links';
 import UnlinkRoute from './unlink';

--- a/api/people/links.ts
+++ b/api/people/links.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../middleware';
@@ -14,7 +14,7 @@ import postLinkApi from './link';
 import { ErrorHelper, getProviders } from '../../transitional';
 import { wrapError } from '../../utils';
 
-const router = express.Router();
+const router: Router = Router();
 
 const unsupportedApiVersions = [
   '2016-12-01',

--- a/api/people/links.ts
+++ b/api/people/links.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { jsonError } from '../../middleware';

--- a/api/people/unlink.ts
+++ b/api/people/unlink.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { ICorporateLink, UnlinkPurpose } from '../../interfaces';
@@ -11,7 +11,7 @@ import { jsonError } from '../../middleware';
 import { IApiRequest } from '../../middleware/apiReposAuth';
 import { getProviders } from '../../transitional';
 
-const router = express.Router();
+const router: Router = Router();
 
 interface ILinksApiRequestWithUnlink extends IApiRequest {
   unlink?: ICorporateLink;

--- a/api/people/unlink.ts
+++ b/api/people/unlink.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { ICorporateLink, UnlinkPurpose } from '../../interfaces';

--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import moment from 'moment';

--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import moment from 'moment';
@@ -14,7 +14,7 @@ import { getProviders } from '../transitional';
 
 import OrganizationWebhookProcessor from '../webhooks/organizationProcessor';
 
-const router = express.Router();
+const router: Router = Router();
 
 interface IRequestWithRaw extends ReposAppRequest {
   _raw?: any;

--- a/middleware/business/administration.ts
+++ b/middleware/business/administration.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';
 

--- a/middleware/business/administration.ts
+++ b/middleware/business/administration.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';

--- a/middleware/react.ts
+++ b/middleware/react.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 
@@ -52,7 +52,7 @@ type CacheBuffer = {
 }
 const localFallbackBlobCache = new Map<string, CacheBuffer>();
 
-export async function TryFallbackToBlob(req: ReposAppRequest, res: express.Response): Promise<boolean> {
+export async function TryFallbackToBlob(req: ReposAppRequest, res: Response): Promise<boolean> {
   if (!req.path) {
     return false;
   }

--- a/middleware/react.ts
+++ b/middleware/react.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Response } from 'express';
+import { Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 

--- a/routes/administration/app.ts
+++ b/routes/administration/app.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { OrganizationSetting, IBasicGitHubAppInstallation, SpecialTeam } from '../../entities/organizationSettings/organizationSetting';
@@ -172,7 +172,7 @@ router.post('/:appId/installations/:installationId', asyncHandler(async function
   const organizationName = installation.account.login;
   const organizationSettingsProvider = providers.organizationSettingsProvider;
 
-  
+
   if (hasElevationButtonClicked) {
     // Only available for pre-adoption
     const [, unconfiguredOrganization] = await getDynamicSettingsFromLegacySettings(providers.operations, staticSettings, installation, individualContext);

--- a/routes/administration/app.ts
+++ b/routes/administration/app.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/administration/apps.ts
+++ b/routes/administration/apps.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { sortByCaseInsensitive } from '../../utils';

--- a/routes/administration/apps.ts
+++ b/routes/administration/apps.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/administration/index.ts
+++ b/routes/administration/index.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';
 import { getProviders } from '../../transitional';

--- a/routes/administration/index.ts
+++ b/routes/administration/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/approvals.ts
+++ b/routes/approvals.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 router.get('/', (req, res) => {
   return res.redirect('/settings/approvals');

--- a/routes/approvals.ts
+++ b/routes/approvals.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 router.get('/', (req, res) => {

--- a/routes/diagnostics.ts
+++ b/routes/diagnostics.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { IAppSession, ReposAppRequest } from '../interfaces';
 import { getProviders } from '../transitional';

--- a/routes/diagnostics.ts
+++ b/routes/diagnostics.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router, Request } from 'express';
+import { Router, Request } from 'express';
 const router: Router = Router();
 
 import { IAppSession, ReposAppRequest } from '../interfaces';

--- a/routes/diagnostics.ts
+++ b/routes/diagnostics.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import express, { Router, Request } from 'express';
 const router: Router = Router();
 
 import { IAppSession, ReposAppRequest } from '../interfaces';
@@ -11,7 +11,7 @@ import { getProviders } from '../transitional';
 
 const redacted = '*****';
 
-interface IRequestWithSession extends express.Request {
+interface IRequestWithSession extends Request {
   app: any;
   session: IAppSession;
   user: any;

--- a/routes/explore.ts
+++ b/routes/explore.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';
 import { getProviders } from '../transitional';

--- a/routes/explore.ts
+++ b/routes/explore.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';

--- a/routes/index-authenticated.ts
+++ b/routes/index-authenticated.ts
@@ -7,9 +7,9 @@
 
 import _ from 'lodash';
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { hasStaticReactClientApp, getProviders } from '../transitional';
 

--- a/routes/index-authenticated.ts
+++ b/routes/index-authenticated.ts
@@ -7,7 +7,7 @@
 
 import _ from 'lodash';
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/index-linked.ts
+++ b/routes/index-linked.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { CreateError, hasStaticReactClientApp, getProviders } from '../transitional';
 import { IndividualContext } from '../user';

--- a/routes/index-linked.ts
+++ b/routes/index-linked.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { webContextMiddleware } from '../middleware/business/setContext';

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { webContextMiddleware } from '../middleware/business/setContext';
 

--- a/routes/link-cleanup.ts
+++ b/routes/link-cleanup.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';
 

--- a/routes/link-cleanup.ts
+++ b/routes/link-cleanup.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';

--- a/routes/link.ts
+++ b/routes/link.ts
@@ -5,9 +5,9 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ReposAppRequest, IAppSession, SupportedLinkType, ICorporateLink, LinkOperationSource } from '../interfaces';
 import { getProviders } from '../transitional';

--- a/routes/link.ts
+++ b/routes/link.ts
@@ -5,7 +5,7 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/2fa.ts
+++ b/routes/org/2fa.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/2fa.ts
+++ b/routes/org/2fa.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import moment from 'moment';
 

--- a/routes/org/index.ts
+++ b/routes/org/index.ts
@@ -5,7 +5,7 @@
 
 import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router()
 
 import { getProviders } from '../../transitional';
 import { IAggregateUserSummary } from '../../user/aggregate';

--- a/routes/org/index.ts
+++ b/routes/org/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router()
 

--- a/routes/org/join.ts
+++ b/routes/org/join.ts
@@ -5,9 +5,9 @@
 
 // the changes in Further-UI-Improvements did not merge well, need to review by hand
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import querystring from 'querystring';
 

--- a/routes/org/join.ts
+++ b/routes/org/join.ts
@@ -5,7 +5,7 @@
 
 // the changes in Further-UI-Improvements did not merge well, need to review by hand
 
-import express, { Router } from 'express';
+import express, { Router, Response, NextFunction } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 
@@ -33,7 +33,7 @@ router.use(function (req: ReposAppRequest, res, next) {
 
 router.use(RequireActiveGitHubSession);
 
-function clearAuditListAndRedirect(res: express.Response, organization: Organization, onboarding: boolean, req: any, state: OrganizationMembershipState) {
+function clearAuditListAndRedirect(res: Response, organization: Organization, onboarding: boolean, req: any, state: OrganizationMembershipState) {
   // Behavior change, only important to those not using GitHub's 2FA enforcement feature; no longer clearing the cache
   const url = organization.baseUrl + 'security-check' + (onboarding ? '?onboarding=' + onboarding : '?joining=' + organization.name);
   if (state === OrganizationMembershipState.Active && req) {
@@ -50,7 +50,7 @@ function queryParamAsBoolean(input: string): boolean {
   }
 }
 
-router.get('/', asyncHandler(async function (req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
+router.get('/', asyncHandler(async function (req: ReposAppRequest, res: Response, next: NextFunction) {
   const providers = getProviders(req);
   const { operations } = providers;
   const organization = req.organization;
@@ -127,7 +127,7 @@ async function addMemberToOrganizationCache(queryCache: QueryCache, organization
   }
 }
 
-router.get('/express', asyncHandler(async function (req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
+router.get('/express', asyncHandler(async function (req: ReposAppRequest, res: Response, next: NextFunction) {
   const providers = getProviders(req);
   const organization = req.organization;
   const onboarding = queryParamAsBoolean(req.query.onboarding as string);
@@ -149,7 +149,7 @@ router.get('/express', asyncHandler(async function (req: ReposAppRequest, res: e
   }
 }));
 
-async function joinOrg(req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
+async function joinOrg(req: ReposAppRequest, res: Response, next: NextFunction) {
   const individualContext = req.individualContext as IndividualContext;
   const organization = req.organization as Organization;
   const onboarding = queryParamAsBoolean(req.query.onboarding as string);
@@ -199,7 +199,7 @@ async function joinOrganization(req, individualContext: IndividualContext, organ
 router.post('/', joinOrg);
 
 // /orgname/join/byClient
-router.post('/byClient', asyncHandler(async (req: ReposAppRequest, res: express.Response, next: express.NextFunction) => {
+router.post('/byClient', asyncHandler(async (req: ReposAppRequest, res: Response, next: NextFunction) => {
   const { queryCache, insights } = getProviders(req);
   const individualContext = req.individualContext as IndividualContext;
   const organization = req.organization as Organization;

--- a/routes/org/join.ts
+++ b/routes/org/join.ts
@@ -5,7 +5,7 @@
 
 // the changes in Further-UI-Improvements did not merge well, need to review by hand
 
-import express, { Router, Response, NextFunction } from 'express';
+import { Router, Response, NextFunction } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/leave.ts
+++ b/routes/org/leave.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { wrapError } from '../../utils';

--- a/routes/org/leave.ts
+++ b/routes/org/leave.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/membership.ts
+++ b/routes/org/membership.ts
@@ -3,13 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { ReposAppRequest, UserAlertType } from '../../interfaces';
 import { wrapError } from '../../utils';
 import RequireActiveGitHubSession from '../../middleware/github/requireActiveSession';
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', RequireActiveGitHubSession, asyncHandler(async function (req: ReposAppRequest, res, next) {
   const organization = req.organization;

--- a/routes/org/membership.ts
+++ b/routes/org/membership.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { ReposAppRequest, UserAlertType } from '../../interfaces';

--- a/routes/org/newRepoSpa.ts
+++ b/routes/org/newRepoSpa.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getRepositoryMetadataProvider, ReposAppRequest } from '../../interfaces';
 import { getProviders } from '../../transitional';

--- a/routes/org/newRepoSpa.ts
+++ b/routes/org/newRepoSpa.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/people.ts
+++ b/routes/org/people.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';
 

--- a/routes/org/people.ts
+++ b/routes/org/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';

--- a/routes/org/profileReview.ts
+++ b/routes/org/profileReview.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 import asyncHandler from 'express-async-handler';
 

--- a/routes/org/profileReview.ts
+++ b/routes/org/profileReview.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 import asyncHandler from 'express-async-handler';
 
 import { ReposAppRequest } from '../../interfaces';

--- a/routes/org/repoAdministrativeLock.ts
+++ b/routes/org/repoAdministrativeLock.ts
@@ -4,7 +4,7 @@
 //
 
 import asyncHandler from 'express-async-handler';
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import _ from 'lodash';

--- a/routes/org/repoAdministrativeLock.ts
+++ b/routes/org/repoAdministrativeLock.ts
@@ -4,8 +4,8 @@
 //
 
 import asyncHandler from 'express-async-handler';
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import _ from 'lodash';
 

--- a/routes/org/repos.ts
+++ b/routes/org/repos.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import _ from 'lodash';
 import moment from 'moment';
@@ -386,7 +386,7 @@ export interface IRepositoryPermissionsView {
 
 export async function calculateGroupedPermissionsViewForRepository(repository: Repository): Promise<any> {
   const organization = repository.organization;
-  const { 
+  const {
     permissions, // TeamPermission[]
     collaborators, // Collaborator[]
     outsideCollaborators, // Collaborator[]

--- a/routes/org/repos.ts
+++ b/routes/org/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/approval/index.ts
+++ b/routes/org/team/approval/index.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../../../transitional';
 import { Team } from '../../../../business';

--- a/routes/org/team/approval/index.ts
+++ b/routes/org/team/approval/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/approvals.ts
+++ b/routes/org/team/approvals.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import RouteApproval from './approval';
 

--- a/routes/org/team/approvals.ts
+++ b/routes/org/team/approvals.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/delete.ts
+++ b/routes/org/team/delete.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../../interfaces';
 

--- a/routes/org/team/delete.ts
+++ b/routes/org/team/delete.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../../interfaces';

--- a/routes/org/team/index-maintainer.ts
+++ b/routes/org/team/index-maintainer.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 
 import { ReposAppRequest } from '../../../interfaces';
 import { wrapError } from '../../../utils';

--- a/routes/org/team/index-maintainer.ts
+++ b/routes/org/team/index-maintainer.ts
@@ -3,11 +3,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 
 import { ReposAppRequest } from '../../../interfaces';
 import { wrapError } from '../../../utils';
-const router = express.Router();
+const router: Router = Router();
 
 import RouteApprovals from './approvals';
 import RouteMembers from './members';

--- a/routes/org/team/index.ts
+++ b/routes/org/team/index.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import throat from 'throat';
 
@@ -189,10 +189,10 @@ router.post('/join', asyncHandler(async (req: ILocalRequest, res, next) => {
 }));
 
 export async function submitTeamJoinRequest(
-  providers: IProviders, 
-  activeContext: IndividualContext, 
-  team: Team, 
-  optionalJustification: string, 
+  providers: IProviders,
+  activeContext: IndividualContext,
+  team: Team,
+  optionalJustification: string,
   correlationId: string,
   hostname: string
   ): Promise<ITeamJoinRequestSubmitOutcome> {

--- a/routes/org/team/index.ts
+++ b/routes/org/team/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/leave.ts
+++ b/routes/org/team/leave.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../../interfaces';
 import { Organization } from '../../../business/organization';

--- a/routes/org/team/leave.ts
+++ b/routes/org/team/leave.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/maintainers.ts
+++ b/routes/org/team/maintainers.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders, validateGitHubLogin } from '../../../transitional';
 import { ReposAppRequest, RequestTeamMemberAddType, NoCacheNoBackground, UserAlertType } from '../../../interfaces';

--- a/routes/org/team/maintainers.ts
+++ b/routes/org/team/maintainers.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/members.ts
+++ b/routes/org/team/members.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { Team, TeamMember } from '../../../business';
 import { ReposAppRequest, RequestTeamMemberAddType, UserAlertType } from '../../../interfaces';

--- a/routes/org/team/members.ts
+++ b/routes/org/team/members.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/org/team/properties.ts
+++ b/routes/org/team/properties.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../../interfaces';
 import { wrapError } from '../../../utils';

--- a/routes/org/team/properties.ts
+++ b/routes/org/team/properties.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../../interfaces';

--- a/routes/org/teams.ts
+++ b/routes/org/teams.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ReposAppRequest } from '../../interfaces';
 import { popSessionVariable } from '../../utils';

--- a/routes/org/teams.ts
+++ b/routes/org/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/orgAdmin.ts
+++ b/routes/orgAdmin.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../transitional';
 

--- a/routes/orgAdmin.ts
+++ b/routes/orgAdmin.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/orgs.ts
+++ b/routes/orgs.ts
@@ -5,7 +5,7 @@
 
 import querystring from 'querystring';
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/orgs.ts
+++ b/routes/orgs.ts
@@ -5,9 +5,9 @@
 
 import querystring from 'querystring';
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { IReposRequestWithOrganization } from '../interfaces';
 import { injectReactClient, TryFallbackToBlob } from '../middleware';

--- a/routes/people.ts
+++ b/routes/people.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { getProviders } from '../transitional';
 import { ReposAppRequest } from '../interfaces';

--- a/routes/people.ts
+++ b/routes/people.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { getProviders } from '../transitional';

--- a/routes/peopleSearch.ts
+++ b/routes/peopleSearch.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../transitional';
 import { RequestWithSystemwidePermissions, RequestTeamMemberAddType } from '../interfaces';

--- a/routes/peopleSearch.ts
+++ b/routes/peopleSearch.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/placeholders.ts
+++ b/routes/placeholders.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';
 import { getProviders } from '../transitional';

--- a/routes/placeholders.ts
+++ b/routes/placeholders.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';

--- a/routes/releasesSpa.ts
+++ b/routes/releasesSpa.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import { ReposAppRequest } from '../interfaces';
 const router: Router = Router();
 

--- a/routes/releasesSpa.ts
+++ b/routes/releasesSpa.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import { ReposAppRequest } from '../interfaces';
-const router = express.Router();
+const router: Router = Router();
 
 router.get('/', function (req: ReposAppRequest, res) {
   req.reposContext = req.reposContext || {};

--- a/routes/repos.ts
+++ b/routes/repos.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';
 import lowercaser from '../middleware/lowercaser';

--- a/routes/repos.ts
+++ b/routes/repos.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { ReposAppRequest } from '../interfaces';

--- a/routes/reposPager.ts
+++ b/routes/reposPager.ts
@@ -4,7 +4,7 @@
 //
 
 import asyncHandler from 'express-async-handler';
-import express, { Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 import _ from 'lodash';
 
 import { daysInMilliseconds } from '../utils';

--- a/routes/reposPager.ts
+++ b/routes/reposPager.ts
@@ -4,7 +4,7 @@
 //
 
 import asyncHandler from 'express-async-handler';
-import express from 'express';
+import express, { Response, NextFunction } from 'express';
 import _ from 'lodash';
 
 import { daysInMilliseconds } from '../utils';
@@ -60,7 +60,7 @@ async function getReposAndOptionalTeamPermissions(organizationId: number, operat
   return { reposData, userRepos };
 }
 
-export default asyncHandler(async function (req: IReposAppWithTeam, res: express.Response, next: express.NextFunction) {
+export default asyncHandler(async function (req: IReposAppWithTeam, res: Response, next: NextFunction) {
   const providers = getProviders(req);
   const operations = providers.operations;
   const queryCache = providers.queryCache;

--- a/routes/settings/approvals.ts
+++ b/routes/settings/approvals.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { IApprovalProvider } from '../../entities/teamJoinApproval/approvalProvider';
 import { TeamJoinApprovalEntity } from '../../entities/teamJoinApproval/teamJoinApproval';

--- a/routes/settings/approvals.ts
+++ b/routes/settings/approvals.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/settings/authorizations.ts
+++ b/routes/settings/authorizations.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { Operations } from '../../business';

--- a/routes/settings/authorizations.ts
+++ b/routes/settings/authorizations.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/settings/campaigns.ts
+++ b/routes/settings/campaigns.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ReposAppRequest, UserAlertType } from '../../interfaces';
 import { CreateError, getProviders } from '../../transitional';

--- a/routes/settings/campaigns.ts
+++ b/routes/settings/campaigns.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/settings/contributionData.ts
+++ b/routes/settings/contributionData.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { ErrorHelper, getProviders } from '../../transitional';
 import { UserSettings } from '../../entities/userSettings';

--- a/routes/settings/contributionData.ts
+++ b/routes/settings/contributionData.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/settings/digestReports.ts
+++ b/routes/settings/digestReports.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { IndividualContext } from '../../user';

--- a/routes/settings/digestReports.ts
+++ b/routes/settings/digestReports.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import { getProviders } from '../../transitional';

--- a/routes/settings/index.ts
+++ b/routes/settings/index.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 

--- a/routes/settings/index.ts
+++ b/routes/settings/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/settings/personalAccessTokens.ts
+++ b/routes/settings/personalAccessTokens.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../../transitional';
 import { PersonalAccessToken } from '../../entities/token/token';

--- a/routes/settings/personalAccessTokens.ts
+++ b/routes/settings/personalAccessTokens.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/teams.ts
+++ b/routes/teams.ts
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
-const router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 import lowercaser from '../middleware/lowercaser';
 import { ReposAppRequest } from '../interfaces';

--- a/routes/teams.ts
+++ b/routes/teams.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 import lowercaser from '../middleware/lowercaser';

--- a/routes/teamsPager.ts
+++ b/routes/teamsPager.ts
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
-import express from 'express';
+import express, { Response, NextFunction } from 'express';
 
 import { getProviders } from '../transitional';
 import { Operations } from '../business';
@@ -73,7 +73,7 @@ function reduceTeams(collections, property, map) {
   });
 }
 
-export default asyncHandler(async function(req: ReposAppRequest, res: express.Response, next: express.NextFunction) {
+export default asyncHandler(async function(req: ReposAppRequest, res: Response, next: NextFunction) {
   const { operations } = getProviders(req);
   const isCrossOrg = req.teamsPagerMode === 'orgs';
   const aggregations = req.individualContext.aggregations;

--- a/routes/teamsPager.ts
+++ b/routes/teamsPager.ts
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
-import express, { Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 
 import { getProviders } from '../transitional';
 import { Operations } from '../business';

--- a/routes/thanks.ts
+++ b/routes/thanks.ts
@@ -7,7 +7,7 @@ import { ReposAppRequest } from '../interfaces';
 import thisPackage = require('../package.json');
 import { getProviders } from '../transitional';
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 const router: Router = Router();
 
 var cachedPackageInformation = null;

--- a/routes/thanks.ts
+++ b/routes/thanks.ts
@@ -7,8 +7,8 @@ import { ReposAppRequest } from '../interfaces';
 import thisPackage = require('../package.json');
 import { getProviders } from '../transitional';
 
-var express = require('express');
-var router = express.Router();
+import express, { Router } from 'express';
+const router: Router = Router();
 
 var cachedPackageInformation = null;
 

--- a/routes/undo.ts
+++ b/routes/undo.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/routes/undo.ts
+++ b/routes/undo.ts
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { Operations, Repository } from '../business';
 import { ErrorHelper, getProviders } from '../transitional';

--- a/routes/unlink.ts
+++ b/routes/unlink.ts
@@ -5,9 +5,9 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-import express from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-const router = express.Router();
+const router: Router = Router();
 
 import { getProviders } from '../transitional';
 import { wrapError } from '../utils';

--- a/routes/unlink.ts
+++ b/routes/unlink.ts
@@ -5,7 +5,7 @@
 
 /*eslint no-console: ["error", { allow: ["warn"] }] */
 
-import express, { Router } from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 const router: Router = Router();
 

--- a/utils.ts
+++ b/utils.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express from 'express';
+import express, { Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
@@ -139,7 +139,7 @@ export function sortByCaseInsensitive(a: string, b: string) {
 // ----------------------------------------------------------------------------
 // Session utility: store the original URL
 // ----------------------------------------------------------------------------
-export function storeOriginalUrlAsReferrer(req: express.Request, res: express.Response, redirect: string, optionalReason?: string) {
+export function storeOriginalUrlAsReferrer(req: Request, res: Response, redirect: string, optionalReason?: string) {
   storeOriginalUrlAsVariable(req, res, 'referer', redirect, optionalReason);
 };
 

--- a/utils.ts
+++ b/utils.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';


### PR DESCRIPTION
Instead of calling `express.Router()` or `express.Request`

I unpacked `Router`, `Request`, `Response` and `NextFunction` from express object and putting them into their own variable. With that it can be easily accessed.