### PR TITLE
Add postgres support for tokens, fix pg init script, fix management url

### DIFF
--- a/business/organization.ts
+++ b/business/organization.ts
@@ -126,7 +126,7 @@ export class Organization {
     if (operationsIsCapable<IOperationsUrls>(operations, CoreCapability.Urls)) {
       this._baseUrl = `${operations.baseUrl}${this.name}/`;
       this._nativeUrl = `${operations.nativeUrl}${this.name}/`;
-      this._nativeManagementUrl = `${operations.nativeManagementUrl}organizations/${this.name}/`;
+      this._nativeManagementUrl = `${operations.nativeManagementUrl}${this.name}/`;
     }
     const withProviders = operations as OperationsCore;
     if (withProviders?.providers) {

--- a/config/entityProviders.json
+++ b/config/entityProviders.json
@@ -17,6 +17,6 @@
 
     "usersettings": "env://ENTITY_PROVIDER_USERSETTINGS?default=firstconfigured",
 
-    "tokens": "env://ENTITY_PROVIDER_TOKENS?default=table",
+    "tokens": "env://ENTITY_PROVIDER_TOKENS?default=firstconfigured",
     "localextensionkey": "env://ENTITY_PROVIDER_LOCALEXTENSIONKEY?default=table"
 }

--- a/entities/token/token.ts
+++ b/entities/token/token.ts
@@ -5,8 +5,7 @@
 
 import crypto from 'crypto';
 
-import {
-  IObjectWithDefinedKeys } from '../../lib/entityMetadataProvider/entityMetadataProvider';
+import { EntityField, IObjectWithDefinedKeys } from '../../lib/entityMetadataProvider/entityMetadataProvider';
 import { EntityMetadataType, IEntityMetadata } from '../../lib/entityMetadataProvider/entityMetadata';
 import { MetadataMappingDefinition, EntityMetadataMappings } from '../../lib/entityMetadataProvider/declarations';
 import { IEntityMetadataFixedQuery, FixedQueryType } from '../../lib/entityMetadataProvider/query';
@@ -16,6 +15,7 @@ import { Type } from './type';
 import { TableSettings } from '../../lib/entityMetadataProvider/table';
 import { MemorySettings } from '../../lib/entityMetadataProvider/memory';
 import { odata, TableEntityQueryOptions } from '@azure/data-tables';
+import { PostgresConfiguration, PostgresJsonEntityQuery, PostgresSettings } from '../../lib/entityMetadataProvider/postgres';
 
 const type = Type;
 
@@ -174,6 +174,41 @@ EntityMetadataMappings.Register(type, TableSettings.TablePossibleDateColumns, [
   Field.created,
   Field.expires,
 ]);
+
+PostgresConfiguration.SetDefaultTableName(type, 'usersettings');
+EntityMetadataMappings.Register(type, PostgresSettings.PostgresDefaultTypeColumnName, 'apiKey');
+PostgresConfiguration.MapFieldsToColumnNames(type, new Map<string, string>([
+  [Field.token, Field.token],
+  [Field.active, Field.active],
+  [Field.corporateId, Field.corporateId],
+  [Field.created, Field.created],
+  [Field.description, Field.description],
+  [Field.source, Field.source],
+  [Field.active, Field.active],
+  [Field.organizationScopes, Field.organizationScopes],
+  [Field.expires, new Date(Field.expires)],
+  [Field.warning, Field.warning],
+  [Field.scopes, Field.scopes],
+]));
+EntityMetadataMappings.Register(type, PostgresSettings.PostgresQueries, (query: IEntityMetadataFixedQuery, mapMetadataPropertiesToFields: string[], metadataColumnName: string, tableName: string, getEntityTypeColumnValue) => {
+  const entityTypeColumn = mapMetadataPropertiesToFields[EntityField.Type];
+  const entityTypeValue = getEntityTypeColumnValue(type);
+  switch (query.fixedQueryType) {
+    case FixedQueryType.TokensByCorporateId:
+      const { corporateId } = query as QueryTokensByCorporateID;
+      if (!corporateId) {
+        throw new Error('corporateId required');
+      }
+      return PostgresJsonEntityQuery(tableName, entityTypeColumn, entityTypeValue, metadataColumnName, {
+        corporateId: corporateId,
+      }, Field.created.toLowerCase(), true);
+    case FixedQueryType.TokensGetAll:
+      return PostgresJsonEntityQuery(tableName, entityTypeColumn, entityTypeValue, metadataColumnName, {}, Field.created.toLowerCase(), true);
+    default:
+      throw new Error(`The fixed query type ${type} is not supported currently by this provider, or is of an unknown type`);
+  }
+});
+
 EntityMetadataMappings.Register(type, TableSettings.TableDefaultTableName, 'settings');
 EntityMetadataMappings.Register(type, TableSettings.TableDefaultFixedPartitionKey, 'apiKey');
 EntityMetadataMappings.Register(type, TableSettings.TableDefaultRowKeyPrefix, 'apiKey');

--- a/pg.sql
+++ b/pg.sql
@@ -60,8 +60,8 @@ CREATE INDEX IF NOT EXISTS events_orgname ON events (organizationname);
 CREATE INDEX IF NOT EXISTS events_orgid ON events (organizationid);
 CREATE INDEX IF NOT EXISTS events_repoid ON events (repositoryid);
 
-ALTER TABLE events ADD COLUMN isowncontribution boolean;
-ALTER TABLE events ADD COLUMN checked timestamptz;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS isowncontribution boolean;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS checked timestamptz;
 
 CREATE INDEX IF NOT EXISTS events_c_isowncontribution ON events (isowncontribution);
 CREATE INDEX IF NOT EXISTS events_checked ON events (checked);


### PR DESCRIPTION
This PR contains three small changes. If I should split them up, let me know. 

- Adds #201 again to allow tokens to be stored in postgres
- Adjust the `pg.sql` script to not fail if the column already exists
- The management link on team management pointed to `https://github.com/orgs/organizations/$ORG/teams/$TEAM/members` included `orgs` and `organizations` and doesn't work.
