### PR TITLE
Fix passthroughMailAddressProvider to match interface

### DIFF
--- a/lib/mailAddressProvider/microsoftMailAddressProvider.ts
+++ b/lib/mailAddressProvider/microsoftMailAddressProvider.ts
@@ -6,7 +6,7 @@
 import { IProviders } from '../../interfaces';
 import { IMailAddressProvider } from '.';
 
-export default function createMailAddressProvider(options) {
+export default function createMailAddressProvider(options) : IMailAddressProvider{
   const config = options.config;
   if (!config.identity || !config.identity.url || !config.identity.pat) {
     throw new Error('Not configured for the Identity service');
@@ -16,7 +16,7 @@ export default function createMailAddressProvider(options) {
     throw new Error('The microsoftMailAddressProvider requires that all provider instances are passed in as options');
   }
   return {
-    getAddressFromUpn: (upn: string) => {
+    getAddressFromUpn: async (upn: string) => {
       return providers.graphProvider.getMailAddressByUsername(upn);
     },
   } as IMailAddressProvider;

--- a/lib/mailAddressProvider/mockMailAddressProvider.ts
+++ b/lib/mailAddressProvider/mockMailAddressProvider.ts
@@ -5,10 +5,10 @@
 
 import { IMailAddressProvider } from '.';
 
-export default function createMailAddressProvider() {
+export default function createMailAddressProvider() : IMailAddressProvider{
   const upnToEmails = new Map();
   return {
-    getAddressFromUpn: async (upn, callback) => {
+    getAddressFromUpn: async (upn: string) => {
       if (upnToEmails.has(upn)) {
         return upnToEmails.get(upn);
       }

--- a/lib/mailAddressProvider/passthroughMailAddressProvider.ts
+++ b/lib/mailAddressProvider/passthroughMailAddressProvider.ts
@@ -3,10 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-export default function createMailAddressProvider() {
+import { IMailAddressProvider } from '.';
+
+export default function createMailAddressProvider() : IMailAddressProvider {
   return {
-    getAddressFromUpn: (upn, callback) => {
-      return callback(null, upn);
+    getAddressFromUpn: async (upn: string) => {
+      return upn;
     },
   };
 }


### PR DESCRIPTION
Update the passthrough mail address provider to match the IMailAddressProvider interface and update the other mail address providers type information.

Current implementation causes a callback is not a function error when called.

![image](https://user-images.githubusercontent.com/12469076/134829065-48277d02-3814-4398-b885-12d675563baa.png)
